### PR TITLE
Fetch data from the family detail endpoint

### DIFF
--- a/src/api/FamilyAPI.js
+++ b/src/api/FamilyAPI.js
@@ -2,4 +2,5 @@ import * as APIUtils from "./APIUtils";
 
 export default {
   getFamilies: () => APIUtils.get("/families"),
+  getFamilyById: (id) => APIUtils.get(`/families/${id}`),
 };

--- a/src/components/registration/FamilyDetailsSidebar.jsx
+++ b/src/components/registration/FamilyDetailsSidebar.jsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-function FamilyDetailsSidebar({ isOpen, rowIndex, handleClose }) {
+function FamilyDetailsSidebar({ isOpen, familyId, handleClose }) {
   const [family, setFamily] = useState({
     parent: { first_name: "", last_name: "" },
   });
@@ -24,10 +24,10 @@ function FamilyDetailsSidebar({ isOpen, rowIndex, handleClose }) {
 
   useEffect(() => {
     async function fetchFamily() {
-      setFamily(await FamilyAPI.getFamilyById(rowIndex + 1));
+      setFamily(await FamilyAPI.getFamilyById(familyId));
     }
-    fetchFamily();
-  }, [rowIndex]);
+    if (familyId) fetchFamily();
+  }, [familyId]);
 
   return (
     <Drawer
@@ -49,12 +49,13 @@ function FamilyDetailsSidebar({ isOpen, rowIndex, handleClose }) {
 
 FamilyDetailsSidebar.defaultProps = {
   isOpen: false,
+  familyId: null,
   handleClose: () => {},
 };
 
 FamilyDetailsSidebar.propTypes = {
   isOpen: PropTypes.bool,
-  rowIndex: PropTypes.number.isRequired,
+  familyId: PropTypes.number,
   handleClose: PropTypes.func,
 };
 

--- a/src/components/registration/FamilyDetailsSidebar.jsx
+++ b/src/components/registration/FamilyDetailsSidebar.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Drawer } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import PropTypes from "prop-types";
+// import getFamilyById from "../../api/FamilyAPI";
 
 const drawerWidth = 250;
 
@@ -15,10 +16,13 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-function FamilyDetailsSidebar({ isOpen, rowData, handleClose }) {
+function FamilyDetailsSidebar({ isOpen, rowIndex, handleClose }) {
   const classes = useStyles();
-  const firstName = rowData[0];
-  const lastName = rowData[1];
+  // useEffect(() => {
+  //   getFamilyById(rowData);
+  // }, []);
+  // const firstName = rowData[0];
+  // const lastName = rowData[1];
   return (
     <Drawer
       anchor="right"
@@ -30,9 +34,7 @@ function FamilyDetailsSidebar({ isOpen, rowData, handleClose }) {
       open={isOpen}
       onClose={handleClose}
     >
-      <h3>
-        Hey {firstName} {lastName}!
-      </h3>
+      <h3>Hey {rowIndex + 1}!</h3>
     </Drawer>
   );
 }
@@ -44,7 +46,7 @@ FamilyDetailsSidebar.defaultProps = {
 
 FamilyDetailsSidebar.propTypes = {
   isOpen: PropTypes.bool,
-  rowData: PropTypes.arrayOf(PropTypes.string).isRequired,
+  rowIndex: PropTypes.number.isRequired,
   handleClose: PropTypes.func,
 };
 

--- a/src/components/registration/FamilyDetailsSidebar.jsx
+++ b/src/components/registration/FamilyDetailsSidebar.jsx
@@ -1,8 +1,8 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Drawer } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import PropTypes from "prop-types";
-// import getFamilyById from "../../api/FamilyAPI";
+import FamilyAPI from "../../api/FamilyAPI";
 
 const drawerWidth = 250;
 
@@ -17,12 +17,18 @@ const useStyles = makeStyles(() => ({
 }));
 
 function FamilyDetailsSidebar({ isOpen, rowIndex, handleClose }) {
+  const [family, setFamily] = useState({
+    parent: { first_name: "", last_name: "" },
+  });
   const classes = useStyles();
-  // useEffect(() => {
-  //   getFamilyById(rowData);
-  // }, []);
-  // const firstName = rowData[0];
-  // const lastName = rowData[1];
+
+  useEffect(() => {
+    async function fetchFamily() {
+      setFamily(await FamilyAPI.getFamilyById(rowIndex + 1));
+    }
+    fetchFamily();
+  }, [rowIndex]);
+
   return (
     <Drawer
       anchor="right"
@@ -34,7 +40,9 @@ function FamilyDetailsSidebar({ isOpen, rowIndex, handleClose }) {
       open={isOpen}
       onClose={handleClose}
     >
-      <h3>Hey {rowIndex + 1}!</h3>
+      <h3>
+        Hey {family.parent.first_name} {family.parent.last_name}!
+      </h3>
     </Drawer>
   );
 }

--- a/src/components/registration/FamilyDetailsSidebar.jsx
+++ b/src/components/registration/FamilyDetailsSidebar.jsx
@@ -17,9 +17,7 @@ const useStyles = makeStyles(() => ({
 }));
 
 function FamilyDetailsSidebar({ isOpen, familyId, handleClose }) {
-  const [family, setFamily] = useState({
-    parent: { first_name: "", last_name: "" },
-  });
+  const [family, setFamily] = useState(null);
   const classes = useStyles();
 
   useEffect(() => {
@@ -41,7 +39,8 @@ function FamilyDetailsSidebar({ isOpen, familyId, handleClose }) {
       onClose={handleClose}
     >
       <h3>
-        Hey {family.parent.first_name} {family.parent.last_name}!
+        Hey {family?.parent?.first_name ?? ""} {family?.parent?.last_name ?? ""}
+        !
       </h3>
     </Drawer>
   );

--- a/src/components/registration/RegistrationTable.jsx
+++ b/src/components/registration/RegistrationTable.jsx
@@ -41,7 +41,14 @@ function getTableRows(families, extraFields) {
 
 function getTableData(families, extraColumns) {
   const rows = getTableRows(families, extraColumns);
-  const columns = [];
+  const columns = [
+    {
+      name: "id",
+      options: {
+        display: "excluded",
+      },
+    },
+  ];
 
   const noWrapText = (value) => (
     <Typography noWrap variant="body2">
@@ -76,10 +83,10 @@ function RegistrationTable({ families }) {
   const { parentFields } = useContext(FieldsContext);
   const [rows, columns] = getTableData(families, parentFields);
   const [openFamilyDetail, setOpenFamilyDetail] = useState(false);
-  const [currentRowIndex, setCurrentRowIndex] = useState(0);
+  const [familyId, setFamilyId] = useState(null);
 
-  const handleOpenFamilyDetail = useCallback((rowData, rowMeta) => {
-    setCurrentRowIndex(rowMeta.rowIndex);
+  const handleOpenFamilyDetail = useCallback((rowData) => {
+    setFamilyId(rowData[0]);
     setOpenFamilyDetail(true);
   }, []);
 
@@ -94,7 +101,7 @@ function RegistrationTable({ families }) {
       <MUIDataTable data={rows} columns={columns} options={options} />
       <FamilyDetailsSidebar
         isOpen={openFamilyDetail}
-        rowIndex={currentRowIndex}
+        familyId={familyId}
         handleClose={handleCloseFamilyDetail}
       />
     </div>

--- a/src/components/registration/RegistrationTable.jsx
+++ b/src/components/registration/RegistrationTable.jsx
@@ -41,14 +41,7 @@ function getTableRows(families, extraFields) {
 
 function getTableData(families, extraColumns) {
   const rows = getTableRows(families, extraColumns);
-  const columns = [
-    {
-      name: "id",
-      options: {
-        display: "excluded",
-      },
-    },
-  ];
+  const columns = [];
 
   const noWrapText = (value) => (
     <Typography noWrap variant="body2">
@@ -86,7 +79,7 @@ function RegistrationTable({ families }) {
   const [familyId, setFamilyId] = useState(null);
 
   const handleOpenFamilyDetail = useCallback((rowData) => {
-    setFamilyId(rowData[0]);
+    setFamilyId(rowData[0].props.children);
     setOpenFamilyDetail(true);
   }, []);
 

--- a/src/components/registration/RegistrationTable.jsx
+++ b/src/components/registration/RegistrationTable.jsx
@@ -77,10 +77,10 @@ function RegistrationTable({ families }) {
   const { parentFields } = useContext(FieldsContext);
   const [rows, columns] = getTableData(families, parentFields);
   const [openFamilyDetail, setOpenFamilyDetail] = useState(false);
-  const [currentRowData, setCurrentRowData] = useState(["", ""]);
+  const [currentRowIndex, setCurrentRowIndex] = useState(0);
 
-  const handleOpenFamilyDetail = useCallback((rowData) => {
-    setCurrentRowData(rowData);
+  const handleOpenFamilyDetail = useCallback((rowData, rowMeta) => {
+    setCurrentRowIndex(rowMeta.rowIndex);
     setOpenFamilyDetail(true);
   }, []);
 
@@ -95,7 +95,7 @@ function RegistrationTable({ families }) {
       <MUIDataTable data={rows} columns={columns} options={options} />
       <FamilyDetailsSidebar
         isOpen={openFamilyDetail}
-        rowData={currentRowData}
+        rowIndex={currentRowIndex}
         handleClose={handleCloseFamilyDetail}
       />
     </div>

--- a/src/components/registration/RegistrationTable.jsx
+++ b/src/components/registration/RegistrationTable.jsx
@@ -2,7 +2,6 @@ import React, { useContext, useState, useCallback } from "react";
 import MUIDataTable from "mui-datatables";
 import PropTypes from "prop-types";
 import { Typography } from "@material-ui/core";
-
 import { FieldsContext } from "../../context/fields";
 import RegistrationTableColumns from "../../constants/registration/RegistrationTableColumns";
 import QuestionTypes from "../../constants/QuestionTypes";

--- a/src/constants/DefaultFields.js
+++ b/src/constants/DefaultFields.js
@@ -7,6 +7,10 @@ const DefaultFields = Object.freeze({
     name: "first_name",
     label: "First Name",
   },
+  ID: {
+    name: "id",
+    label: "Id",
+  },
   LAST_NAME: {
     name: "last_name",
     label: "Last Name",

--- a/src/constants/registration/RegistrationTableColumns.js
+++ b/src/constants/registration/RegistrationTableColumns.js
@@ -2,6 +2,11 @@ import DefaultFields from "../DefaultFields";
 
 const RegistrationTableColumns = [
   {
+    name: DefaultFields.ID.name,
+    label: DefaultFields.ID.label,
+    options: { display: "excluded" },
+  },
+  {
     name: DefaultFields.FIRST_NAME.name,
     label: DefaultFields.FIRST_NAME.label,
     options: { filter: false },


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Fetch data from the family detail endpoint](https://www.notion.so/uwblueprintexecs/Fetch-data-from-the-family-detail-endpoint-8ecd3aa122a4482cbe3f400e51248e0b)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- Added a new API action in `FamilyAPI`
- Created a new state object and update it with useEffect depending on if the rowIndex changes 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Click on a bunch of different rows in the main registration table, and validate that the sidebar slides in from the right has the correct parent first name and last name 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- Check my work with hooks, still learning!
- I get rowIndex from the table, hoping that's the best way to do it

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
