### PR TITLE
[2/5] Create registration dialog shell

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -2,12 +2,20 @@ import React from "react";
 import { useHistory } from "react-router-dom";
 import { AppBar, Button, IconButton, Toolbar } from "@material-ui/core";
 import { AccountCircle } from "@material-ui/icons";
+import { makeStyles } from "@material-ui/styles";
+
+const useStyles = makeStyles(() => ({
+  navbar: {
+    backgroundColor: "#F3F3F3",
+  },
+}));
 
 function Navbar() {
+  const classes = useStyles();
   const history = useHistory();
 
   return (
-    <AppBar>
+    <AppBar className={classes.navbar}>
       <Toolbar>
         <div style={{ marginLeft: "auto" }}>
           <Button onClick={() => history.push("/")}>All registrations</Button>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -20,7 +20,7 @@ function Navbar() {
         <div style={{ marginLeft: "auto" }}>
           <Button onClick={() => history.push("/")}>All registrations</Button>
           <Button onClick={() => history.push("/sessions")}>Sessions</Button>
-          <IconButton edge="end" aria-label="account" color="inherit">
+          <IconButton edge="end" aria-label="account">
             <AccountCircle />
           </IconButton>
         </div>

--- a/src/components/registration/RegistrationDialog.jsx
+++ b/src/components/registration/RegistrationDialog.jsx
@@ -1,0 +1,69 @@
+import React, { useCallback, useState } from "react";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Typography,
+} from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import { Close, NavigateBefore } from "@material-ui/icons";
+import PropTypes from "prop-types";
+import RegistrationForm from "./RegistrationForm";
+
+const useStyles = makeStyles((theme) => ({
+  closeButton: {
+    position: "absolute",
+    right: theme.spacing(1),
+    top: theme.spacing(1),
+    color: theme.palette.grey[500],
+  },
+}));
+
+function RegistrationFormDialog({ onClose }) {
+  const classes = useStyles();
+  const [displayForm, setDisplayForm] = useState(false);
+
+  const handleDisplayForm = useCallback(() => {
+    setDisplayForm(true);
+  }, []);
+
+  const handleHideForm = useCallback(() => {
+    setDisplayForm(false);
+  }, []);
+
+  return (
+    <Dialog open disableBackdropClick onClose={onClose} fullWidth maxWidth="lg">
+      <DialogTitle disableTypography>
+        <Typography variant="h2">Add a client</Typography>
+        <IconButton
+          aria-label="close"
+          onClick={onClose}
+          className={classes.closeButton}
+        >
+          <Close />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent>
+        {displayForm ? (
+          <>
+            <Button onClick={handleHideForm}>
+              <NavigateBefore />
+              Go back
+            </Button>
+            <RegistrationForm />
+          </>
+        ) : (
+          <Button onClick={handleDisplayForm}>Register a new client</Button>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+RegistrationFormDialog.propTypes = {
+  onClose: PropTypes.func.isRequired,
+};
+
+export default RegistrationFormDialog;

--- a/src/components/registration/RegistrationDialog.jsx
+++ b/src/components/registration/RegistrationDialog.jsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function RegistrationFormDialog({ onClose }) {
+function RegistrationFormDialog({ open, onClose }) {
   const classes = useStyles();
   const [displayForm, setDisplayForm] = useState(false);
 
@@ -33,7 +33,13 @@ function RegistrationFormDialog({ onClose }) {
   };
 
   return (
-    <Dialog open disableBackdropClick onClose={onClose} fullWidth maxWidth="lg">
+    <Dialog
+      open={open}
+      onClose={onClose}
+      disableBackdropClick
+      fullWidth
+      maxWidth="lg"
+    >
       <DialogTitle disableTypography>
         <Typography component="h2" variant="h4">
           Add a client
@@ -64,6 +70,7 @@ function RegistrationFormDialog({ onClose }) {
 }
 
 RegistrationFormDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
 };
 

--- a/src/components/registration/RegistrationDialog.jsx
+++ b/src/components/registration/RegistrationDialog.jsx
@@ -35,7 +35,9 @@ function RegistrationFormDialog({ onClose }) {
   return (
     <Dialog open disableBackdropClick onClose={onClose} fullWidth maxWidth="lg">
       <DialogTitle disableTypography>
-        <Typography variant="h2">Add a client</Typography>
+        <Typography component="h2" variant="h4">
+          Add a client
+        </Typography>
         <IconButton
           aria-label="close"
           onClick={onClose}

--- a/src/components/registration/RegistrationDialog.jsx
+++ b/src/components/registration/RegistrationDialog.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useState } from "react";
 import {
   Button,
   Dialog,
@@ -17,7 +17,6 @@ const useStyles = makeStyles((theme) => ({
     position: "absolute",
     right: theme.spacing(1),
     top: theme.spacing(1),
-    color: theme.palette.grey[500],
   },
 }));
 
@@ -25,13 +24,13 @@ function RegistrationFormDialog({ onClose }) {
   const classes = useStyles();
   const [displayForm, setDisplayForm] = useState(false);
 
-  const handleDisplayForm = useCallback(() => {
+  const handleDisplayForm = () => {
     setDisplayForm(true);
-  }, []);
+  };
 
-  const handleHideForm = useCallback(() => {
+  const handleHideForm = () => {
     setDisplayForm(false);
-  }, []);
+  };
 
   return (
     <Dialog open disableBackdropClick onClose={onClose} fullWidth maxWidth="lg">

--- a/src/components/registration/RegistrationForm.jsx
+++ b/src/components/registration/RegistrationForm.jsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { Typography } from "@material-ui/core";
+
+function RegistrationForm() {
+  return <Typography>Currently enrolling a new family</Typography>;
+}
+
+export default RegistrationForm;

--- a/src/pages/Sessions.jsx
+++ b/src/pages/Sessions.jsx
@@ -7,7 +7,7 @@ import RegistrationDialog from "../components/registration/RegistrationDialog";
 
 function Sessions() {
   const [sessions, setSessions] = useState([]);
-  const [displayRegDialog, setDisplayRegDialog] = React.useState(false);
+  const [displayRegDialog, setDisplayRegDialog] = useState(false);
 
   useEffect(() => {
     async function fetchSessions() {

--- a/src/pages/Sessions.jsx
+++ b/src/pages/Sessions.jsx
@@ -16,24 +16,24 @@ function Sessions() {
     fetchSessions();
   }, []);
 
-  const handleFormDialogOpen = () => {
+  const handleOpenFormDialog = () => {
     setDisplayRegDialog(true);
   };
 
-  const handleFormDialogClose = () => {
+  const handleCloseFormDialog = () => {
     setDisplayRegDialog(false);
   };
 
   return (
     <>
       <Typography variant="h1">Sessions</Typography>
-      <Button variant="outlined" onClick={handleFormDialogOpen}>
+      <Button variant="outlined" onClick={handleOpenFormDialog}>
         New registrant
         <Add />
       </Button>
       <RegistrationDialog
         open={displayRegDialog}
-        onClose={handleFormDialogClose}
+        onClose={handleCloseFormDialog}
       />
       {sessions.length ? (
         <ul>

--- a/src/pages/Sessions.jsx
+++ b/src/pages/Sessions.jsx
@@ -31,9 +31,10 @@ function Sessions() {
         New registrant
         <Add />
       </Button>
-      {displayRegDialog && (
-        <RegistrationDialog onClose={handleFormDialogClose} />
-      )}
+      <RegistrationDialog
+        open={displayRegDialog}
+        onClose={handleFormDialogClose}
+      />
       {sessions.length ? (
         <ul>
           {sessions.map((session) => (

--- a/src/pages/Sessions.jsx
+++ b/src/pages/Sessions.jsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useState } from "react";
-import { Typography } from "@material-ui/core";
+import { Button, Typography } from "@material-ui/core";
+import { Add } from "@material-ui/icons";
 
 import SessionAPI from "../api/SessionAPI";
+import RegistrationDialog from "../components/registration/RegistrationDialog";
 
 function Sessions() {
   const [sessions, setSessions] = useState([]);
+  const [displayRegDialog, setDisplayRegDialog] = React.useState(false);
 
   useEffect(() => {
     async function fetchSessions() {
@@ -13,9 +16,24 @@ function Sessions() {
     fetchSessions();
   }, []);
 
+  const handleFormDialogOpen = () => {
+    setDisplayRegDialog(true);
+  };
+
+  const handleFormDialogClose = () => {
+    setDisplayRegDialog(false);
+  };
+
   return (
     <>
       <Typography variant="h1">Sessions</Typography>
+      <Button variant="outlined" onClick={handleFormDialogOpen}>
+        New registrant
+        <Add />
+      </Button>
+      {displayRegDialog && (
+        <RegistrationDialog onClose={handleFormDialogClose} />
+      )}
       {sessions.length ? (
         <ul>
           {sessions.map((session) => (

--- a/src/shared/PrivateRoute.jsx
+++ b/src/shared/PrivateRoute.jsx
@@ -24,7 +24,6 @@ function PrivateRoute({ component: Component, ...rest }) {
 
 PrivateRoute.propTypes = {
   component: PropTypes.elementType.isRequired,
-  location: PropTypes.objectOf(PropTypes.object).isRequired,
 };
 
 export default PrivateRoute;

--- a/src/shared/PrivateRoute.jsx
+++ b/src/shared/PrivateRoute.jsx
@@ -24,6 +24,7 @@ function PrivateRoute({ component: Component, ...rest }) {
 
 PrivateRoute.propTypes = {
   component: PropTypes.elementType.isRequired,
+  location: PropTypes.objectOf(PropTypes.object).isRequired,
 };
 
 export default PrivateRoute;

--- a/src/theme.js
+++ b/src/theme.js
@@ -5,9 +5,6 @@ const defaultTheme = createMuiTheme();
 const theme = createMuiTheme({
   palette: {
     type: "light",
-    primary: {
-      main: "#F3F3F3",
-    },
   },
   overrides: {
     MuiContainer: {


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Registration form modal shell](https://www.notion.so/uwblueprintexecs/9cb454262ed84c6299c0682c23f92ec5?v=1076bd30711a4a01838becee05f8b5a3&p=e0143b8253524334b986f573d3eaa375)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- created a new `RegistrationDialog` component that's opened with the "new registrant" button on the sessions page
- created a `RegistrationForm` stub component that will contain the form contents
- within the dialog, if users click "Register a new client", the form will appear
- fixed some styling stuff

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. `yarn start`
2. go to /sessions and click "New registrant" - the dialog should open
3. click "Register a new client" - some text showing "Currently enrolling a new family" should appear
4. click "Go back" - this should hide the text, and show the "Register a new client" button again

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- testing!
- good react practices

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
