### PR TITLE
[3/5] Add question type to default fields and define family/student defaults

### DIFF
--- a/src/constants/DefaultFields.js
+++ b/src/constants/DefaultFields.js
@@ -1,32 +1,73 @@
-const DefaultFields = Object.freeze({
+import QuestionTypes from "./QuestionTypes";
+
+export const DefaultFields = Object.freeze({
   EMAIL: {
-    name: "email",
-    label: "Email",
+    id: "email",
+    name: "Email",
+    question_type: QuestionTypes.TEXT,
+  },
+  CELL_PHONE: {
+    id: "cell_number",
+    name: "Cell Phone",
+    question_type: QuestionTypes.TEXT,
   },
   FIRST_NAME: {
-    name: "first_name",
-    label: "First Name",
+    id: "first_name",
+    name: "First name",
+    question_type: QuestionTypes.TEXT,
+  },
+  HOME_PHONE: {
+    id: "home_number",
+    name: "Home Phone",
+    question_type: QuestionTypes.TEXT,
   },
   ID: {
-    name: "id",
-    label: "Id",
+    id: "id",
+    name: "Id",
+    question_type: QuestionTypes.TEXT,
   },
   LAST_NAME: {
-    name: "last_name",
-    label: "Last Name",
+    id: "last_name",
+    name: "Last name",
+    question_type: QuestionTypes.TEXT,
   },
   NUM_CHILDREN: {
-    name: "num_children",
-    label: "No. of Children",
+    id: "num_children",
+    name: "No. of Children",
+    question_type: QuestionTypes.TEXT,
   },
   PHONE: {
-    name: "phone_number",
-    label: "Phone Number",
+    id: "phone_number",
+    name: "Phone Number",
+    question_type: QuestionTypes.TEXT,
   },
   PREFERRED_CONTACT: {
-    name: "preferred_comms",
-    label: "Preferred Contact",
+    id: "preferred_comms",
+    name: "Preferred Contact",
+    question_type: QuestionTypes.MULTIPLE_CHOICE,
+  },
+  PREFERRED_NUMBER: {
+    id: "preferred_number",
+    name: "Preferred Number",
+    question_type: QuestionTypes.MULTIPLE_CHOICE,
+  },
+  WORK_PHONE: {
+    id: "work_number",
+    name: "Work Phone",
+    question_type: QuestionTypes.TEXT,
   },
 });
 
-export default DefaultFields;
+export const DefaultFamilyFields = [
+  DefaultFields.HOME_PHONE,
+  DefaultFields.CELL_PHONE,
+  DefaultFields.WORK_PHONE,
+  DefaultFields.PREFERRED_NUMBER,
+  DefaultFields.EMAIL,
+  DefaultFields.PREFERRED_CONTACT,
+];
+
+export const DefaultStudentFields = [
+  DefaultFields.FIRST_NAME,
+  DefaultFields.LAST_NAME,
+];

--- a/src/constants/registration/FamilyTableColumns.js
+++ b/src/constants/registration/FamilyTableColumns.js
@@ -1,39 +1,39 @@
-import DefaultFields from "../DefaultFields";
+import { DefaultFields } from "../DefaultFields";
 
 const FamilyTableColumns = [
   {
-    name: DefaultFields.ID.name,
-    label: DefaultFields.ID.label,
+    name: DefaultFields.ID.id,
+    label: DefaultFields.ID.name,
     options: { display: "excluded" },
   },
   {
-    name: DefaultFields.FIRST_NAME.name,
-    label: DefaultFields.FIRST_NAME.label,
+    name: DefaultFields.FIRST_NAME.id,
+    label: DefaultFields.FIRST_NAME.name,
     options: { filter: false },
   },
   {
-    name: DefaultFields.LAST_NAME.name,
-    label: DefaultFields.LAST_NAME.label,
+    name: DefaultFields.LAST_NAME.id,
+    label: DefaultFields.LAST_NAME.name,
     options: { filter: false },
   },
   {
-    name: DefaultFields.EMAIL.name,
-    label: DefaultFields.EMAIL.label,
+    name: DefaultFields.EMAIL.id,
+    label: DefaultFields.EMAIL.name,
     options: { filter: false },
   },
   {
-    name: DefaultFields.PHONE.name,
-    label: DefaultFields.PHONE.label,
+    name: DefaultFields.PHONE.id,
+    label: DefaultFields.PHONE.name,
     options: { filter: false },
   },
   {
-    name: DefaultFields.NUM_CHILDREN.name,
-    label: DefaultFields.NUM_CHILDREN.label,
+    name: DefaultFields.NUM_CHILDREN.id,
+    label: DefaultFields.NUM_CHILDREN.name,
     options: { searchable: false, filterOptions: { fullWidth: true } },
   },
   {
-    name: DefaultFields.PREFERRED_CONTACT.name,
-    label: DefaultFields.PREFERRED_CONTACT.label,
+    name: DefaultFields.PREFERRED_CONTACT.id,
+    label: DefaultFields.PREFERRED_CONTACT.name,
     options: { searchable: false, filterOptions: { fullWidth: true } },
   },
 ];


### PR DESCRIPTION
reworking the default fields constants a bit for use in the registration form - we need information about the question type of each, as well as which ones should apply to the student/family models

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- add question types to default fields
- add `DefaultFamilyFields` and `DefaultStudentFields` constants for the mandatory fields (for the POST /family request that'll be made)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

no changes to the end user experience!
1. `yarn start`
2. verify that the reg table columns show up as before

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- rebasing if your work is impacted by this!

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
