### PR TITLE
[TS migration] Move sessions page to Typescript 📦

### DIFF
--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -4,15 +4,16 @@ import { Add } from "@material-ui/icons";
 
 import SessionAPI from "../api/SessionAPI";
 import RegistrationDialog from "../components/registration/RegistrationDialog";
+import { Session } from "../types";
 
-function Sessions() {
-  const [sessions, setSessions] = useState([]);
+const Sessions = () => {
+  const [sessions, setSessions] = useState<Session[]>([]);
   const [displayRegDialog, setDisplayRegDialog] = useState(false);
 
   useEffect(() => {
-    async function fetchSessions() {
+    const fetchSessions = async () => {
       setSessions(await SessionAPI.getSessions());
-    }
+    };
     fetchSessions();
   }, []);
 
@@ -50,6 +51,6 @@ function Sessions() {
       )}
     </>
   );
-}
+};
 
 export default Sessions;

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -26,3 +26,11 @@ export type Family = {
   [DefaultFieldName.PREFERRED_CONTACT]: string;
   parent: Student;
 };
+
+export type Session = {
+  fields: number[]; // array of field IDs
+  id: number;
+  season: string;
+  start_date: string;
+  year: number;
+};


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[TS migration](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=e47e78d6b54e4120aa13f06bb61640c5)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- moved pages/Sessions.jsx to pages/Session.tsx
- added type for sessions

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. `yarn start`
2. verify the sessions page loads as expected!

<img width="1536" alt="Screen Shot 2021-05-18 at 11 44 49 AM" src="https://user-images.githubusercontent.com/37346399/118682455-76d8d580-b7ce-11eb-8bba-90194e3e2f2e.png">

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- ts best practices

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
