### PR TITLE
Select session on the sessions page

### DIFF
--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -1,5 +1,13 @@
 import React, { useEffect, useState } from "react";
-import { Button, Typography } from "@material-ui/core";
+import {
+  Box,
+  Button,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Typography,
+} from "@material-ui/core";
 import { Add } from "@material-ui/icons";
 
 import SessionAPI from "../api/SessionAPI";
@@ -8,11 +16,16 @@ import { Session } from "../types";
 
 const Sessions = () => {
   const [sessions, setSessions] = useState<Session[]>([]);
+  const [currentSessionId, setCurrentSessionId] = useState<number>();
   const [displayRegDialog, setDisplayRegDialog] = useState(false);
 
   useEffect(() => {
     const fetchSessions = async () => {
-      setSessions(await SessionAPI.getSessions());
+      const sessionsData = await SessionAPI.getSessions();
+      setSessions(sessionsData);
+      if (sessionsData.length) {
+        setCurrentSessionId(sessionsData[0].id); // most recent session
+      }
     };
     fetchSessions();
   }, []);
@@ -25,31 +38,54 @@ const Sessions = () => {
     setDisplayRegDialog(false);
   };
 
+  const handleChangeCurrentSessionId = (
+    e: React.ChangeEvent<{ value: unknown }>
+  ) => {
+    setCurrentSessionId(e.target.value as number);
+  };
+
   return (
-    <>
-      <Typography variant="h1">Sessions</Typography>
-      <Button variant="outlined" onClick={handleOpenFormDialog}>
-        New registrant
-        <Add />
-      </Button>
-      <RegistrationDialog
-        open={displayRegDialog}
-        onClose={handleCloseFormDialog}
-      />
-      {sessions.length ? (
-        <ul>
-          {sessions.map((session) => (
-            <li key={session.id}>
-              <Typography variant="body1">
-                {session.id} - {session.season} {session.year}
-              </Typography>
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <p>No sessions found</p>
+    <Box display="flex">
+      <Box display="flex" flexGrow={1} alignItems="center">
+        <Box mr={3}>
+          <Typography variant="h1">Session:</Typography>
+        </Box>
+        <Box>
+          {currentSessionId && (
+            <FormControl variant="outlined">
+              <InputLabel id="session">Session</InputLabel>
+              <Select
+                id="select"
+                label="session"
+                labelId="session"
+                value={currentSessionId}
+                onChange={handleChangeCurrentSessionId}
+              >
+                {sessions.map((session) => (
+                  <MenuItem key={session.id} value={session.id}>
+                    {session.season} {session.year}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+        </Box>
+      </Box>
+      {currentSessionId && (
+        <>
+          <Box flexShrink={0}>
+            <Button variant="outlined" onClick={handleOpenFormDialog}>
+              New registrant
+              <Add />
+            </Button>
+          </Box>
+          <RegistrationDialog
+            open={displayRegDialog}
+            onClose={handleCloseFormDialog}
+          />
+        </>
       )}
-    </>
+    </Box>
   );
 };
 

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -75,7 +75,7 @@ const Sessions = () => {
         <>
           <Box flexShrink={0}>
             <Button variant="outlined" onClick={handleOpenFormDialog}>
-              New registrant
+              Add a client
               <Add />
             </Button>
           </Box>


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Allow users to select a session](https://www.notion.so/uwblueprintexecs/Session-and-class-default-views-4aadab28b3ee42038f9eac07566a6435?p=32112f41a4ef463fbd24183281887baf)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- storing state for a current session ID on the sessions page, and added a select component
- formatted the session page header

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. run the backend (with sessions existing)
2. go to the sessions page & play with the selector!

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- code quality, extensibility

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
