### PR TITLE
add test job to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           at: .
       - run:
           name: Unit Tests
-          command: yarn test . --passWithNoTests
+          command: yarn test .
 
 workflows:
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,12 +6,43 @@ jobs:
       - image: circleci/python:3.9-node
     steps:
       - checkout
+      - restore_cache:
+          name: Restore Yarn Package Cache
+          keys:
+            - yarn-packages-{{ checksum "yarn.lock" }}
       - run:
           name: Install dependencies
           command: yarn
+      - save_cache:
+          name: Save Yarn Package Cache
+          key: yarn-packages-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache/yarn
       - run:
           name: Eslint
           command: yarn run eslint --fix .
       - run:
           name: Prettier
           command: yarn prettier --write .
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+  test:
+    docker:
+      - image: circleci/python:3.9-node
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Unit Tests
+          command: yarn test .
+
+workflows:
+  build_and_test:
+    jobs:
+      - build
+      - test:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           at: .
       - run:
           name: Unit Tests
-          command: yarn test .
+          command: yarn test . --passWithNoTests
 
 workflows:
   build_and_test:


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Ensure automated tests pass CI](https://www.notion.so/uwblueprintexecs/Ensure-automated-tests-pass-in-CI-c883376b4076478790cbf97cd9269718)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- Create a build job and a test job
- Run them sequentially, test job runs after build job passes
- Refer to [this template](https://circleci.com/docs/2.0/sample-config/#sequential-workflow) of a sequential workflow
- Add dependency caching, example [here](https://circleci.com/docs/2.0/yarn/#caching)
- Add workspace to save project state between jobs. Concept diagram [here](https://circleci.com/docs/2.0/concepts/#caches-workspaces-and-artifacts)
- Add environment variable under circleci project settings. [See here for reference](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- Good CI practices

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR