### PR TITLE
[TS migration] Move family API helper to Typescript 📦

### DIFF
--- a/src/api/FamilyAPI.js
+++ b/src/api/FamilyAPI.js
@@ -1,7 +1,0 @@
-import * as APIUtils from "./APIUtils";
-
-export default {
-  getFamilies: () => APIUtils.get("/families/"),
-  getFamilyById: (id) => APIUtils.get(`/families/${id}`),
-  postFamily: (data) => APIUtils.post("/families/", data),
-};

--- a/src/api/FamilyAPI.ts
+++ b/src/api/FamilyAPI.ts
@@ -1,0 +1,61 @@
+import DefaultFieldKey from "../constants/DefaultFieldKey";
+import { Family, Student } from "../types";
+import * as APIUtils from "./APIUtils";
+
+export type FamilyDetailResponse = Pick<
+  Family,
+  | DefaultFieldKey.ADDRESS
+  | DefaultFieldKey.CELL_NUMBER
+  | DefaultFieldKey.EMAIL
+  | DefaultFieldKey.HOME_NUMBER
+  | DefaultFieldKey.ID
+  | DefaultFieldKey.PREFERRED_CONTACT
+  | DefaultFieldKey.PREFERRED_NUMBER
+  | DefaultFieldKey.WORK_NUMBER
+  | "children"
+  | "guests"
+  | "parent"
+>;
+
+export type FamilyListResponse = Pick<
+  Family,
+  | DefaultFieldKey.CURRENT_CLASS
+  | DefaultFieldKey.EMAIL
+  | DefaultFieldKey.ENROLLED
+  | DefaultFieldKey.ID
+  | DefaultFieldKey.NUM_CHILDREN
+  | DefaultFieldKey.PHONE_NUMBER
+  | DefaultFieldKey.PREFERRED_CONTACT
+  | DefaultFieldKey.STATUS
+  | "parent"
+>;
+
+type StudentRequest = Pick<
+  Student,
+  DefaultFieldKey.FIRST_NAME | DefaultFieldKey.LAST_NAME | "information"
+>;
+
+export type FamilyRequest = Pick<
+  Family,
+  | DefaultFieldKey.ADDRESS
+  | DefaultFieldKey.CELL_NUMBER
+  | DefaultFieldKey.EMAIL
+  | DefaultFieldKey.HOME_NUMBER
+  | DefaultFieldKey.PREFERRED_CONTACT
+  | DefaultFieldKey.PREFERRED_NUMBER
+  | DefaultFieldKey.WORK_NUMBER
+> & {
+  children: StudentRequest[];
+  guests: StudentRequest[];
+  parent: StudentRequest;
+};
+
+const getFamilies = (): Promise<FamilyListResponse[]> =>
+  APIUtils.get("/families/");
+
+const getFamilyById = (id: number): Promise<FamilyDetailResponse> =>
+  APIUtils.get(`/families/${id}`);
+
+const postFamily = (data: FamilyRequest) => APIUtils.post("/families/", data);
+
+export default { getFamilies, getFamilyById, postFamily };

--- a/src/components/families/FamilyDetailsSidebar.tsx
+++ b/src/components/families/FamilyDetailsSidebar.tsx
@@ -3,8 +3,7 @@ import { Drawer, Divider, Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import { DefaultFamilyFormFields } from "../../constants/DefaultFields";
 import { DynamicFieldsContext } from "../../context/DynamicFieldsContext";
-import FamilyAPI from "../../api/FamilyAPI";
-import { Family } from "../../types";
+import FamilyAPI, { FamilyDetailResponse } from "../../api/FamilyAPI";
 
 const drawerWidth = 400;
 
@@ -33,7 +32,7 @@ const FamilyDetailsSidebar = ({
   handleClose,
 }: FamilyDetailsSidebarProps) => {
   const { parentDynamicFields } = useContext(DynamicFieldsContext);
-  const [family, setFamily] = useState<Family>();
+  const [family, setFamily] = useState<FamilyDetailResponse>();
   const classes = useStyles();
 
   useEffect(() => {

--- a/src/components/families/FamilyTable.tsx
+++ b/src/components/families/FamilyTable.tsx
@@ -6,7 +6,7 @@ import MUIDataTable, {
 import { Typography } from "@material-ui/core";
 import { DynamicFieldsContext } from "../../context/DynamicFieldsContext";
 import FamilyDetailsSidebar from "./FamilyDetailsSidebar";
-import { DefaultField, DynamicField, Family } from "../../types";
+import { DefaultField, DynamicField } from "../../types";
 import DefaultFieldKey from "../../constants/DefaultFieldKey";
 import {
   DefaultFamilyTableFields,
@@ -14,6 +14,7 @@ import {
   DefaultFields,
 } from "../../constants/DefaultFields";
 import QuestionTypes from "../../constants/QuestionTypes";
+import { FamilyListResponse } from "../../api/FamilyAPI";
 
 const options: MUIDataTableOptions = {
   responsive: "standard",
@@ -29,7 +30,7 @@ const noWrapText = (value: string): ReactNode => (
 );
 
 type FamilyTableRow = Pick<
-  Family,
+  FamilyListResponse,
   | DefaultFieldKey.CURRENT_CLASS
   | DefaultFieldKey.EMAIL
   | DefaultFieldKey.ENROLLED
@@ -45,7 +46,7 @@ type FamilyTableRow = Pick<
 };
 
 type FamilyTableProps = {
-  families: Family[];
+  families: FamilyListResponse[];
 };
 
 const FamilyTable = ({ families }: FamilyTableProps) => {

--- a/src/pages/MainRegistration.tsx
+++ b/src/pages/MainRegistration.tsx
@@ -1,13 +1,10 @@
-import React, { useEffect, useState, useContext } from "react";
+import React, { useEffect, useState } from "react";
 import { Typography } from "@material-ui/core";
-
-import FamilyAPI from "../api/FamilyAPI";
+import FamilyAPI, { FamilyListResponse } from "../api/FamilyAPI";
 import FamilyTable from "../components/families/FamilyTable";
-import { AuthContext } from "../context/auth";
 
-function MainRegistration() {
-  const [families, setFamilies] = useState([]);
-  const { user } = useContext(AuthContext);
+const MainRegistration = () => {
+  const [families, setFamilies] = useState<FamilyListResponse[]>([]);
 
   useEffect(() => {
     async function fetchFamilies() {
@@ -19,12 +16,9 @@ function MainRegistration() {
   return (
     <>
       <Typography variant="h1">Main registration</Typography>
-      <Typography variant="h2">
-        Hi {user ? user.email : "anonymous user"}
-      </Typography>
       <FamilyTable families={families} />
     </>
   );
-}
+};
 
 export default MainRegistration;

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -20,21 +20,26 @@ export type Student = {
   [DefaultFieldKey.FIRST_NAME]: string;
   [DefaultFieldKey.LAST_NAME]: string;
   id: number;
-  information: {
-    [key: number]: string | number; // dynamic fields
-  };
+  information: Record<number, string>; // dynamic fields
   role: StudentRole;
 };
 
 export type Family = {
+  [DefaultFieldKey.ADDRESS]: string;
+  [DefaultFieldKey.CELL_NUMBER]: string;
   [DefaultFieldKey.CURRENT_CLASS]: string;
   [DefaultFieldKey.EMAIL]: string;
   [DefaultFieldKey.ENROLLED]: string;
+  [DefaultFieldKey.HOME_NUMBER]: string;
   [DefaultFieldKey.ID]: number;
   [DefaultFieldKey.NUM_CHILDREN]: number;
   [DefaultFieldKey.PHONE_NUMBER]: string;
   [DefaultFieldKey.PREFERRED_CONTACT]: string;
+  [DefaultFieldKey.PREFERRED_NUMBER]: string;
   [DefaultFieldKey.STATUS]: string;
+  [DefaultFieldKey.WORK_NUMBER]: string;
+  children: Student[];
+  guests: Student[];
   parent: Student;
 };
 


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[TS migration](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=e47e78d6b54e4120aa13f06bb61640c5)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- moved FamilyAPI.jsx → FamilyAPI.tsx
  - defined types for API responses & requests, based on the backend serializers
  - updated FamilyTable and FamilyDetailsSidebar to use these types
- moved MainRegistration.jsx → MainRegistration.tsx

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. `yarn start`
2. verify that the family table and details sidebar open as expected

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- ts best practices

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
