### PR TITLE
added children column to main registration table

### DIFF
--- a/src/components/families/FamilyTable.tsx
+++ b/src/components/families/FamilyTable.tsx
@@ -41,7 +41,7 @@ type FamilyTableRow = Pick<
 > & {
   [DefaultFieldKey.FIRST_NAME]: string;
   [DefaultFieldKey.LAST_NAME]: string;
-  [DefaultFieldKey.CHILDREN_INFO]: string;
+  [DefaultFieldKey.CHILDREN]: string;
   [key: number]: string | number; // dynamic fields
 };
 
@@ -83,7 +83,7 @@ const FamilyTable = ({ families }: FamilyTableProps) => {
       const familyRow: FamilyTableRow = {
         [DefaultFieldKey.FIRST_NAME]: parent.first_name,
         [DefaultFieldKey.LAST_NAME]: parent.last_name,
-        [DefaultFieldKey.CHILDREN_INFO]: childrenInfo,
+        [DefaultFieldKey.CHILDREN]: childrenInfo,
         ...args,
       };
       parentDynamicFields.forEach((field) => {

--- a/src/components/families/FamilyTable.tsx
+++ b/src/components/families/FamilyTable.tsx
@@ -41,11 +41,23 @@ type FamilyTableRow = Pick<
 > & {
   [DefaultFieldKey.FIRST_NAME]: string;
   [DefaultFieldKey.LAST_NAME]: string;
+  [DefaultFieldKey.CHILDREN_INFO]: string;
   [key: number]: string | number; // dynamic fields
 };
 
 type FamilyTableProps = {
   families: Family[];
+};
+
+const getAge = (dateString: string): number => {
+  const today = new Date();
+  const birthDate = new Date(dateString);
+  let age = today.getFullYear() - birthDate.getFullYear();
+  const m = today.getMonth() - birthDate.getMonth();
+  if (m < 0 || (m === 0 && today.getDate() < birthDate.getDate())) {
+    age -= 1;
+  }
+  return age;
 };
 
 const FamilyTable = ({ families }: FamilyTableProps) => {
@@ -54,10 +66,24 @@ const FamilyTable = ({ families }: FamilyTableProps) => {
   const [familyId, setFamilyId] = useState<number>();
 
   const getTableRows = (): FamilyTableRow[] =>
-    families.map(({ parent, ...args }) => {
+    families.map(({ parent, children, ...args }) => {
+      let childrenInfo = "";
+      children.forEach((child, i) => {
+        if (child.date_of_birth != null) {
+          childrenInfo += `${child.first_name} (${getAge(
+            child.date_of_birth
+          )})`;
+        } else {
+          childrenInfo += `${child.first_name} (N/A)`;
+        }
+        if (i < children.length - 1) {
+          childrenInfo += ", ";
+        }
+      });
       const familyRow: FamilyTableRow = {
         [DefaultFieldKey.FIRST_NAME]: parent.first_name,
         [DefaultFieldKey.LAST_NAME]: parent.last_name,
+        [DefaultFieldKey.CHILDREN_INFO]: childrenInfo,
         ...args,
       };
       parentDynamicFields.forEach((field) => {

--- a/src/constants/DefaultFieldKey.ts
+++ b/src/constants/DefaultFieldKey.ts
@@ -1,6 +1,7 @@
 enum DefaultFieldKey {
   ADDRESS = "address",
   CELL_NUMBER = "cell_number",
+  CHILDREN = "children",
   CURRENT_CLASS = "current_class",
   EMAIL = "email",
   ENROLLED = "enrolled",
@@ -9,7 +10,6 @@ enum DefaultFieldKey {
   ID = "id",
   LAST_NAME = "last_name",
   NUM_CHILDREN = "num_children",
-  CHILDREN_INFO = "children",
   PHONE_NUMBER = "phone_number",
   PREFERRED_CONTACT = "preferred_comms",
   PREFERRED_NUMBER = "preferred_number",

--- a/src/constants/DefaultFieldKey.ts
+++ b/src/constants/DefaultFieldKey.ts
@@ -9,6 +9,7 @@ enum DefaultFieldKey {
   ID = "id",
   LAST_NAME = "last_name",
   NUM_CHILDREN = "num_children",
+  CHILDREN_INFO = "children",
   PHONE_NUMBER = "phone_number",
   PREFERRED_CONTACT = "preferred_comms",
   PREFERRED_NUMBER = "preferred_number",

--- a/src/constants/DefaultFields.ts
+++ b/src/constants/DefaultFields.ts
@@ -63,10 +63,10 @@ export const DefaultFields: Record<string, DefaultField> = Object.freeze({
     name: "No. of children",
     question_type: QuestionTypes.TEXT,
   },
-  CHILDREN_INFO: {
-    id: DefaultFieldKey.CHILDREN_INFO,
+  CHILDREN: {
+    id: DefaultFieldKey.CHILDREN,
     is_default: true,
-    name: "Children (Age)",
+    name: "Children",
     question_type: QuestionTypes.TEXT,
   },
   PHONE_NUMBER: {
@@ -108,7 +108,7 @@ export const DefaultFamilyTableFields: DefaultField[] = [
   DefaultFields.PHONE_NUMBER,
   DefaultFields.EMAIL,
   DefaultFields.NUM_CHILDREN,
-  DefaultFields.CHILDREN_INFO,
+  DefaultFields.CHILDREN,
   DefaultFields.PREFERRED_CONTACT,
   // can expand to view
   DefaultFields.CELL_NUMBER,

--- a/src/constants/DefaultFields.ts
+++ b/src/constants/DefaultFields.ts
@@ -63,6 +63,12 @@ export const DefaultFields: Record<string, DefaultField> = Object.freeze({
     name: "No. of children",
     question_type: QuestionTypes.TEXT,
   },
+  CHILDREN_INFO: {
+    id: DefaultFieldKey.CHILDREN_INFO,
+    is_default: true,
+    name: "Children (Age)",
+    question_type: QuestionTypes.TEXT,
+  },
   PHONE_NUMBER: {
     id: DefaultFieldKey.PHONE_NUMBER,
     is_default: true,
@@ -102,6 +108,7 @@ export const DefaultFamilyTableFields: DefaultField[] = [
   DefaultFields.PHONE_NUMBER,
   DefaultFields.EMAIL,
   DefaultFields.NUM_CHILDREN,
+  DefaultFields.CHILDREN_INFO,
   DefaultFields.PREFERRED_CONTACT,
   // can expand to view
   DefaultFields.CELL_NUMBER,

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -33,7 +33,7 @@ export type Family = {
   [DefaultFieldKey.ENROLLED]: string;
   [DefaultFieldKey.ID]: number;
   [DefaultFieldKey.NUM_CHILDREN]: number;
-  [DefaultFieldKey.CHILDREN_INFO]: Student[];
+  [DefaultFieldKey.CHILDREN]: Student[];
   [DefaultFieldKey.PHONE_NUMBER]: string;
   [DefaultFieldKey.PREFERRED_CONTACT]: string;
   [DefaultFieldKey.STATUS]: string;

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -24,6 +24,7 @@ export type Student = {
     [key: number]: string | number; // dynamic fields
   };
   role: StudentRole;
+  date_of_birth: string;
 };
 
 export type Family = {
@@ -32,6 +33,7 @@ export type Family = {
   [DefaultFieldKey.ENROLLED]: string;
   [DefaultFieldKey.ID]: number;
   [DefaultFieldKey.NUM_CHILDREN]: number;
+  [DefaultFieldKey.CHILDREN_INFO]: Student[];
   [DefaultFieldKey.PHONE_NUMBER]: string;
   [DefaultFieldKey.PREFERRED_CONTACT]: string;
   [DefaultFieldKey.STATUS]: string;


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

["Children" column](https://www.notion.so/uwblueprintexecs/9cb454262ed84c6299c0682c23f92ec5?v=1076bd30711a4a01838becee05f8b5a3&p=d159dadec85f44bd9aba8745a24b6105)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- added a "children" column to the main registration table, displaying the first name and age of each child in the family.

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. start the frontend and look at the registration table :)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- clean code, typescript conventions, etc.

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
