### PR TITLE
Create reusable date input

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@date-io/moment": "1.x",
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
+    "@material-ui/pickers": "^3.3.10",
     "@material-ui/styles": "^4.11.3",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
@@ -14,6 +16,7 @@
     "@types/react": "^17.0.5",
     "@types/react-dom": "^17.0.3",
     "firebase": "^8.3.0",
+    "moment": "^2.29.1",
     "mui-datatables": "^3.7.6",
     "prop-types": "^15.7.2",
     "react": "^17.0.1",

--- a/src/components/common/inputs/DateInput.tsx
+++ b/src/components/common/inputs/DateInput.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import moment from "moment";
+import { Box, InputLabel } from "@material-ui/core";
+import { DatePicker } from "@material-ui/pickers";
+import { InputProps } from "../../../types";
+
+type Props = InputProps & {
+  value: Date;
+  onChange: (value: Date) => void;
+};
+
+const DateInput = ({ id, label, value, onChange, inputWidth }: Props) => (
+  <Box display="flex" flexDirection="row" alignItems="center" marginY={2}>
+    <Box paddingRight={2} width={150}>
+      <InputLabel htmlFor={id}>{label}</InputLabel>
+    </Box>
+    <Box width={inputWidth}>
+      <DatePicker
+        id={id}
+        autoOk
+        disableToolbar
+        variant="inline"
+        inputVariant="outlined"
+        format="MMMM D, yyyy"
+        value={value}
+        onChange={(date) => onChange(moment(date).toDate())}
+        fullWidth
+      />
+    </Box>
+  </Box>
+);
+
+export default DateInput;

--- a/src/components/common/inputs/SelectInput.tsx
+++ b/src/components/common/inputs/SelectInput.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { Box, InputLabel, MenuItem, Select } from "@material-ui/core";
-import { InputProps } from "../../../types";
+import { StringInputProps } from "../../../types";
 
-type Props = InputProps & {
+type Props = StringInputProps & {
   options: string[];
 };
 

--- a/src/components/common/inputs/TextInput.tsx
+++ b/src/components/common/inputs/TextInput.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Box, InputLabel, OutlinedInput } from "@material-ui/core";
-import { InputProps } from "../../../types";
+import { StringInputProps } from "../../../types";
 
 const TextInput = ({
   id,
@@ -9,7 +9,7 @@ const TextInput = ({
   onChange,
   inputWidth,
   testId,
-}: InputProps) => (
+}: StringInputProps) => (
   <Box display="flex" flexDirection="row" alignItems="center" marginY={2}>
     {/* hidden input to disable autocomplete: https://gist.github.com/niksumeiko/360164708c3b326bd1c8#gistcomment-3716208 */}
     <Box display="none" aria-hidden="true">

--- a/src/shared/ProjectREAD.jsx
+++ b/src/shared/ProjectREAD.jsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { Container } from "@material-ui/core";
+import MomentUtils from "@date-io/moment";
+import { MuiPickersUtilsProvider } from "@material-ui/pickers";
 
 import { DynamicFieldsProvider } from "../context/DynamicFieldsContext";
 import Navbar from "../components/Navbar";
@@ -12,8 +14,10 @@ function ProjectREAD() {
     <DynamicFieldsProvider>
       <Container maxWidth={false}>
         <Navbar />
-        <PrivateRoute exact path="/" component={MainRegistration} />
-        <PrivateRoute exact path="/sessions" component={Sessions} />
+        <MuiPickersUtilsProvider utils={MomentUtils}>
+          <PrivateRoute exact path="/" component={MainRegistration} />
+          <PrivateRoute exact path="/sessions" component={Sessions} />
+        </MuiPickersUtilsProvider>
       </Container>
     </DynamicFieldsProvider>
   );

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -56,8 +56,11 @@ export type Session = {
 export type InputProps = {
   id: string;
   label: string;
-  value: string;
-  onChange: (value: string) => void;
   inputWidth?: number;
   testId?: string;
+};
+
+export type StringInputProps = InputProps & {
+  value: string;
+  onChange: (value: string) => void;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1164,6 +1164,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.6.0":
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.12.13", "@babel/template@^7.3.3":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
@@ -1217,6 +1224,18 @@
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
+
+"@date-io/core@1.x", "@date-io/core@^1.3.13":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@date-io/core/-/core-1.3.13.tgz#90c71da493f20204b7a972929cc5c482d078b3fa"
+  integrity sha512-AlEKV7TxjeK+jxWVKcCFrfYAk8spX9aCyiToFIiLPtfQbsjmRGLIhb5VZgptQcJdHtLXo7+m0DuurwFgUToQuA==
+
+"@date-io/moment@1.x":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@date-io/moment/-/moment-1.3.13.tgz#56c2772bc4f6675fc6970257e6033e7a7c2960f0"
+  integrity sha512-3kJYusJtQuOIxq6byZlzAHoW/18iExJer9qfRF5DyyzdAk074seTuJfdofjz4RFfTd/Idk8WylOQpWtERqvFuQ==
+  dependencies:
+    "@date-io/core" "^1.3.13"
 
 "@emotion/hash@^0.8.0":
   version "0.8.0"
@@ -1720,6 +1739,18 @@
   integrity sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==
   dependencies:
     "@babel/runtime" "^7.4.4"
+
+"@material-ui/pickers@^3.3.10":
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/@material-ui/pickers/-/pickers-3.3.10.tgz#f1b0f963348cc191645ef0bdeff7a67c6aa25485"
+  integrity sha512-hS4pxwn1ZGXVkmgD4tpFpaumUaAg2ZzbTrxltfC5yPw4BJV+mGkfnQOB4VpWEYZw2jv65Z0wLwDE/piQiPPZ3w==
+  dependencies:
+    "@babel/runtime" "^7.6.0"
+    "@date-io/core" "1.x"
+    "@types/styled-jsx" "^2.2.8"
+    clsx "^1.0.2"
+    react-transition-group "^4.0.0"
+    rifm "^0.7.0"
 
 "@material-ui/styles@^4.11.3", "@material-ui/styles@^4.11.4":
   version "4.11.4"
@@ -2291,6 +2322,13 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
+
+"@types/styled-jsx@^2.2.8":
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/@types/styled-jsx/-/styled-jsx-2.2.8.tgz#b50d13d8a3c34036282d65194554cf186bab7234"
+  integrity sha512-Yjye9VwMdYeXfS71ihueWRSxrruuXTwKCbzue4+5b2rjnQ//AtyM7myZ1BEhNhBQ/nL/RE7bdToUoLln2miKvg==
+  dependencies:
+    "@types/react" "*"
 
 "@types/tapable@^1", "@types/tapable@^1.0.5":
   version "1.0.7"
@@ -3757,7 +3795,7 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
-clsx@^1.0.4, clsx@^1.1.1:
+clsx@^1.0.2, clsx@^1.0.4, clsx@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
@@ -8078,6 +8116,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+moment@^2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -10061,6 +10104,16 @@ react-to-print@^2.8.0:
   dependencies:
     prop-types "^15.7.2"
 
+react-transition-group@^4.0.0:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
+  integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+
 react-transition-group@^4.4.0:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
@@ -10484,6 +10537,13 @@ rgba-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
+
+rifm@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/rifm/-/rifm-0.7.0.tgz#debe951a9c83549ca6b33e5919f716044c2230be"
+  integrity sha512-DSOJTWHD67860I5ojetXdEQRIBvF6YcpNe53j0vn1vp9EUb9N80EiZTxgP+FkDKorWC8PZw052kTF4C1GOivCQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
 
 rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Make reusable form field inputs](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=42b46b9b76d740a29585de1d2fd3ed00)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- created a `DateInput` that opens a date picker
- installs the @material-ui/pickers library (recommended by the [mui docs](https://material-ui.com/components/pickers/#material-ui-pickers))
- will add unit tests later, trying to get this done to unblock a task next sprint

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. will be used in an upcoming PR

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- code quality
- anything missing?

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
