### PR TITLE
Implement searching for an existing family by parent name

### DIFF
--- a/src/api/FamilyAPI.ts
+++ b/src/api/FamilyAPI.ts
@@ -68,7 +68,7 @@ export type FamilyStudentRequest = FamilyRequest & {
 const getFamilies = (): Promise<FamilyListResponse[]> =>
   APIUtils.get("/families/");
 
-const searchFamiliesByParent = (
+const getFamiliesByParentName = (
   firstName: string,
   lastName: string
 ): Promise<FamilySearchResponse[]> =>
@@ -84,7 +84,7 @@ const postFamily = (data: FamilyStudentRequest) =>
 
 export default {
   getFamilies,
-  searchFamiliesByParent,
+  getFamiliesByParentName,
   getFamilyById,
   postFamily,
 };

--- a/src/api/FamilyAPI.ts
+++ b/src/api/FamilyAPI.ts
@@ -32,6 +32,17 @@ export type FamilyListResponse = Pick<
   | "parent"
 >;
 
+export type FamilySearchResponse = Pick<
+  Family,
+  | DefaultFieldKey.EMAIL
+  | DefaultFieldKey.ID
+  | DefaultFieldKey.NUM_CHILDREN
+  | DefaultFieldKey.PHONE_NUMBER
+> & {
+  [DefaultFieldKey.FIRST_NAME]: string;
+  [DefaultFieldKey.LAST_NAME]: string;
+};
+
 export type FamilyRequest = Pick<
   Family,
   | DefaultFieldKey.ADDRESS
@@ -57,12 +68,10 @@ export type FamilyStudentRequest = FamilyRequest & {
 const getFamilies = (): Promise<FamilyListResponse[]> =>
   APIUtils.get("/families/");
 
-// search/?first_name="
-//           + query_params["first_name"]
-//           + "&last_name="
-//           + query_params["last_name"]
-
-const getFamilySearch = (firstName: string, lastName: string): Promise<any> =>
+const searchFamiliesByParent = (
+  firstName: string,
+  lastName: string
+): Promise<FamilySearchResponse[]> =>
   APIUtils.get(
     `/families/search/?first_name=${firstName}&last_name=${lastName}`
   );
@@ -73,4 +82,9 @@ const getFamilyById = (id: number): Promise<FamilyDetailResponse> =>
 const postFamily = (data: FamilyStudentRequest) =>
   APIUtils.post("/families/", data);
 
-export default { getFamilies, getFamilyById, postFamily, getFamilySearch };
+export default {
+  getFamilies,
+  searchFamiliesByParent,
+  getFamilyById,
+  postFamily,
+};

--- a/src/api/FamilyAPI.ts
+++ b/src/api/FamilyAPI.ts
@@ -57,10 +57,20 @@ export type FamilyStudentRequest = FamilyRequest & {
 const getFamilies = (): Promise<FamilyListResponse[]> =>
   APIUtils.get("/families/");
 
+// search/?first_name="
+//           + query_params["first_name"]
+//           + "&last_name="
+//           + query_params["last_name"]
+
+const getFamilySearch = (firstName: string, lastName: string): Promise<any> =>
+  APIUtils.get(
+    `/families/search/?first_name=${firstName}&last_name=${lastName}`
+  );
+
 const getFamilyById = (id: number): Promise<FamilyDetailResponse> =>
   APIUtils.get(`/families/${id}`);
 
 const postFamily = (data: FamilyStudentRequest) =>
   APIUtils.post("/families/", data);
 
-export default { getFamilies, getFamilyById, postFamily };
+export default { getFamilies, getFamilyById, postFamily, getFamilySearch };

--- a/src/components/family-search/family-search-results-table/FamilySearchResultsTable.tsx
+++ b/src/components/family-search/family-search-results-table/FamilySearchResultsTable.tsx
@@ -12,10 +12,14 @@ import {
 } from "@material-ui/core";
 import { makeStyles } from "@material-ui/styles";
 import { FamilySearchResponse } from "../../../api/FamilyAPI";
+import { DefaultFields } from "../../../constants/DefaultFields";
 
 const useStyles = makeStyles(() => ({
   noResultsTableCell: {
     textAlign: "center",
+  },
+  tableContainer: {
+    maxHeight: 250,
   },
 }));
 
@@ -26,17 +30,21 @@ type Props = {
 const FamilySearchResultsTable = ({ families }: Props) => {
   const classes = useStyles();
   return (
-    <Box marginY={2} maxHeight={350}>
-      <TableContainer component={Paper} elevation={0}>
+    <Box marginY={2}>
+      <TableContainer
+        component={Paper}
+        elevation={0}
+        className={classes.tableContainer}
+      >
         <Table stickyHeader aria-label="family search results table">
           <caption hidden>Family search results</caption>
           <TableHead>
             <TableRow>
-              <TableCell>First Name</TableCell>
-              <TableCell>Last Name</TableCell>
-              <TableCell>Primary Phone Number</TableCell>
-              <TableCell>Email</TableCell>
-              <TableCell># of Children</TableCell>
+              <TableCell>{DefaultFields.FIRST_NAME.name}</TableCell>
+              <TableCell>{DefaultFields.LAST_NAME.name}</TableCell>
+              <TableCell>{DefaultFields.PHONE_NUMBER.name}</TableCell>
+              <TableCell>{DefaultFields.EMAIL.name}</TableCell>
+              <TableCell>{DefaultFields.NUM_CHILDREN.name}</TableCell>
             </TableRow>
           </TableHead>
           {families.length ? (

--- a/src/components/family-search/family-search-results-table/FamilySearchResultsTable.tsx
+++ b/src/components/family-search/family-search-results-table/FamilySearchResultsTable.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import {
+  Box,
+  Paper,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  TableFooter,
+  TableContainer,
+} from "@material-ui/core";
+import { makeStyles } from "@material-ui/styles";
+import { FamilySearchResponse } from "../../../api/FamilyAPI";
+
+const useStyles = makeStyles(() => ({
+  noResultsTableCell: {
+    textAlign: "center",
+  },
+}));
+
+type Props = {
+  families: FamilySearchResponse[];
+};
+
+const FamilySearchResultsTable = ({ families }: Props) => {
+  const classes = useStyles();
+  return (
+    <Box marginY={2} maxHeight={350}>
+      <TableContainer component={Paper} elevation={0}>
+        <Table stickyHeader aria-label="family search results table">
+          <caption hidden>Family search results</caption>
+          <TableHead>
+            <TableRow>
+              <TableCell>First Name</TableCell>
+              <TableCell>Last Name</TableCell>
+              <TableCell>Primary Phone Number</TableCell>
+              <TableCell>Email</TableCell>
+              <TableCell># of Children</TableCell>
+            </TableRow>
+          </TableHead>
+          {families.length ? (
+            <TableBody>
+              {families.map((family) => (
+                <TableRow>
+                  <TableCell>{family.first_name}</TableCell>
+                  <TableCell>{family.last_name}</TableCell>
+                  <TableCell>{family.phone_number}</TableCell>
+                  <TableCell>{family.email}</TableCell>
+                  <TableCell>{family.num_children}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          ) : (
+            <TableFooter>
+              <TableRow>
+                <TableCell colSpan={5} className={classes.noResultsTableCell}>
+                  No results found
+                </TableCell>
+              </TableRow>
+            </TableFooter>
+          )}
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+};
+
+export default FamilySearchResultsTable;

--- a/src/components/family-search/family-search-results-table/index.ts
+++ b/src/components/family-search/family-search-results-table/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./FamilySearchResultsTable";

--- a/src/components/family-search/student-search-bar/StudentSearchBar.tsx
+++ b/src/components/family-search/student-search-bar/StudentSearchBar.tsx
@@ -2,15 +2,17 @@ import React, { useState } from "react";
 import { Button, Box, TextField } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import { Search } from "@material-ui/icons";
+import { DefaultFields } from "../../../constants/DefaultFields";
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme) => ({
   button: {
     boxShadow: "none",
     height: 55,
     minWidth: 55,
   },
   input: {
-    marginRight: 16,
+    marginRight: theme.spacing(2),
+    width: 328,
   },
 }));
 
@@ -45,19 +47,21 @@ const StudentSearchBar = ({
     <Box marginY={2}>
       <form onSubmit={handleSubmit}>
         <TextField
+          id={DefaultFields.FIRST_NAME.id}
           className={classes.input}
           error={hasError}
           helperText={hasError && "Please enter a value"}
           variant="outlined"
-          placeholder="First name"
+          placeholder={DefaultFields.FIRST_NAME.name}
           value={firstName}
           onChange={(e) => onChangeFirstName(e.target.value)}
         />
         <TextField
+          id={DefaultFields.LAST_NAME.id}
           className={classes.input}
           error={hasError}
           variant="outlined"
-          placeholder="Last name"
+          placeholder={DefaultFields.LAST_NAME.name}
           value={lastName}
           onChange={(e) => onChangeLastName(e.target.value)}
         />

--- a/src/components/family-search/student-search-bar/StudentSearchBar.tsx
+++ b/src/components/family-search/student-search-bar/StudentSearchBar.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from "react";
+import { Button, Box, TextField } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import { Search } from "@material-ui/icons";
+
+const useStyles = makeStyles(() => ({
+  button: {
+    boxShadow: "none",
+    height: 55,
+    minWidth: 55,
+  },
+  input: {
+    marginRight: 16,
+  },
+}));
+
+type Props = {
+  firstName: string;
+  lastName: string;
+  onChangeFirstName: (name: string) => void;
+  onChangeLastName: (name: string) => void;
+  onSubmit: () => void;
+};
+
+const StudentSearchBar = ({
+  firstName,
+  lastName,
+  onChangeFirstName,
+  onChangeLastName,
+  onSubmit,
+}: Props) => {
+  const classes = useStyles();
+  const [hasError, setHasError] = useState(false);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const isError = firstName === "" && lastName === "";
+    setHasError(isError);
+    if (!isError) {
+      onSubmit();
+    }
+  };
+
+  return (
+    <Box marginY={2}>
+      <form onSubmit={handleSubmit}>
+        <TextField
+          className={classes.input}
+          error={hasError}
+          helperText={hasError && "Please enter a value"}
+          variant="outlined"
+          placeholder="First name"
+          value={firstName}
+          onChange={(e) => onChangeFirstName(e.target.value)}
+        />
+        <TextField
+          className={classes.input}
+          error={hasError}
+          variant="outlined"
+          placeholder="Last name"
+          value={lastName}
+          onChange={(e) => onChangeLastName(e.target.value)}
+        />
+        <Button
+          type="submit"
+          aria-label="search"
+          variant="contained"
+          color="primary"
+          className={classes.button}
+        >
+          <Search />
+        </Button>
+      </form>
+    </Box>
+  );
+};
+
+export default StudentSearchBar;

--- a/src/components/family-search/student-search-bar/StudentSearchBar.tsx
+++ b/src/components/family-search/student-search-bar/StudentSearchBar.tsx
@@ -45,7 +45,7 @@ const StudentSearchBar = ({
 
   return (
     <Box marginY={2}>
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={handleSubmit} autoComplete="off">
         <TextField
           id={DefaultFields.FIRST_NAME.id}
           className={classes.input}

--- a/src/components/family-search/student-search-bar/index.ts
+++ b/src/components/family-search/student-search-bar/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./StudentSearchBar";

--- a/src/components/registration/RegistrationDialog.tsx
+++ b/src/components/registration/RegistrationDialog.tsx
@@ -19,7 +19,10 @@ import {
 import { makeStyles } from "@material-ui/core/styles";
 import { Close, Search, NavigateBefore } from "@material-ui/icons";
 import RegistrationForm from "./RegistrationForm";
-import FamilyAPI, { FamilyStudentRequest } from "../../api/FamilyAPI";
+import FamilyAPI, {
+  FamilySearchResponse,
+  FamilyStudentRequest,
+} from "../../api/FamilyAPI";
 
 const useStyles = makeStyles((theme) => ({
   closeButton: {
@@ -55,8 +58,9 @@ const RegistrationFormDialog = ({
   const [lastName, setLastName] = useState("");
   const [validInput, setValidInput] = useState(true);
   const [displayResults, setDisplayResults] = useState(false);
-
-  const [familyResponse, setFamilyResponse] = useState<any[]>([]);
+  const [familyResults, setFamilyResults] = useState<FamilySearchResponse[]>(
+    []
+  );
 
   const handleDisplayForm = () => {
     setDisplayForm(true);
@@ -86,7 +90,9 @@ const RegistrationFormDialog = ({
     if (firstName || lastName) {
       setDisplayResults(true);
       setValidInput(true);
-      setFamilyResponse(await FamilyAPI.getFamilySearch(firstName, lastName));
+      setFamilyResults(
+        await FamilyAPI.searchFamiliesByParent(firstName, lastName)
+      );
     } else {
       setDisplayResults(false);
       setValidInput(false);
@@ -166,9 +172,9 @@ const RegistrationFormDialog = ({
                         <TableCell># of Children</TableCell>
                       </TableRow>
                     </TableHead>
-                    {familyResponse.length ? (
+                    {familyResults.length ? (
                       <TableBody>
-                        {familyResponse.map((family) => (
+                        {familyResults.map((family) => (
                           <TableRow>
                             <TableCell>{family.first_name}</TableCell>
                             <TableCell>{family.last_name}</TableCell>

--- a/src/components/registration/RegistrationDialog.tsx
+++ b/src/components/registration/RegistrationDialog.tsx
@@ -1,28 +1,22 @@
 import React, { useState } from "react";
 import {
-  Button,
   Box,
+  Button,
   Dialog,
   DialogContent,
   DialogTitle,
   IconButton,
   Typography,
-  TextField,
-  Table,
-  TableHead,
-  TableBody,
-  TableRow,
-  TableCell,
-  TableFooter,
-  TableContainer,
 } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
-import { Close, Search, NavigateBefore } from "@material-ui/icons";
+import { Close, NavigateBefore } from "@material-ui/icons";
 import RegistrationForm from "./RegistrationForm";
 import FamilyAPI, {
   FamilySearchResponse,
   FamilyStudentRequest,
 } from "../../api/FamilyAPI";
+import FamilySearchResultsTable from "../family-search/family-search-results-table";
+import StudentSearchBar from "../family-search/student-search-bar";
 
 const useStyles = makeStyles((theme) => ({
   closeButton: {
@@ -30,14 +24,16 @@ const useStyles = makeStyles((theme) => ({
     right: theme.spacing(1),
     top: theme.spacing(1),
   },
-  searchSection: {
-    paddingTop: theme.spacing(1),
-    paddingBottom: theme.spacing(1),
+  dialogHeading: {
+    marginBottom: 8,
   },
-  searchButton: {
-    height: theme.spacing(5),
-    width: theme.spacing(4),
-    margin: "8px",
+  dialogTitle: {
+    marginBottom: 16,
+  },
+  registerButton: {
+    borderRadius: 18,
+    paddingLeft: 24,
+    paddingRight: 24,
   },
 }));
 
@@ -56,7 +52,6 @@ const RegistrationFormDialog = ({
   /* eslint-disable @typescript-eslint/no-unused-vars */
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
-  const [validInput, setValidInput] = useState(true);
   const [displayResults, setDisplayResults] = useState(false);
   const [familyResults, setFamilyResults] = useState<FamilySearchResponse[]>(
     []
@@ -87,16 +82,10 @@ const RegistrationFormDialog = ({
   };
 
   const onSearchSubmit = async () => {
-    if (firstName || lastName) {
-      setDisplayResults(true);
-      setValidInput(true);
-      setFamilyResults(
-        await FamilyAPI.searchFamiliesByParent(firstName, lastName)
-      );
-    } else {
-      setDisplayResults(false);
-      setValidInput(false);
-    }
+    setDisplayResults(true);
+    setFamilyResults(
+      await FamilyAPI.searchFamiliesByParent(firstName, lastName)
+    );
   };
 
   return (
@@ -108,7 +97,9 @@ const RegistrationFormDialog = ({
       maxWidth="md"
     >
       <DialogTitle disableTypography>
-        <Typography variant="h2">Add a client</Typography>
+        <Typography variant="h2" className={classes.dialogTitle}>
+          Add a client
+        </Typography>
         <IconButton
           aria-label="close"
           onClick={onClose}
@@ -119,97 +110,40 @@ const RegistrationFormDialog = ({
       </DialogTitle>
 
       <DialogContent style={{ minHeight: "500px" }}>
-        {displaySearch ? (
+        {displaySearch && (
           <>
-            <Typography component="h2" variant="h6">
+            <Typography variant="h3" className={classes.dialogHeading}>
               Search for a client
             </Typography>
-            <Typography component="h1" variant="body1">
-              Make sure the client being registered isn’t already enrolled.
-            </Typography>
-            <Box>
-              <TextField // should these be FormFieldGroup components? Add feature to "wipe" user-entered when dialog closes so that each opening is a clean slate
-                error={!validInput}
-                helperText={validInput ? null : "Please enter a value"}
-                variant="outlined"
-                margin="dense"
-                placeholder="First name"
-                style={{ marginRight: "10px" }}
-                value={firstName}
-                onChange={(e) => setFirstName(e.target.value)}
+            <Box marginBottom={3}>
+              <Typography variant="body1">
+                Make sure the client being registered isn’t already enrolled.
+              </Typography>
+              <StudentSearchBar
+                firstName={firstName}
+                lastName={lastName}
+                onChangeFirstName={setFirstName}
+                onChangeLastName={setLastName}
+                onSubmit={onSearchSubmit}
               />
-              <TextField
-                error={!validInput}
-                variant="outlined"
-                margin="dense"
-                placeholder="Last name"
-                value={lastName}
-                onChange={(e) => setLastName(e.target.value)}
-              />
-              <Button
-                aria-label="search"
-                variant="contained"
-                color="primary"
-                onClick={onSearchSubmit}
-                className={classes.searchButton}
-              >
-                <Search />
-              </Button>
             </Box>
-            {displayResults ? (
-              <Box className={classes.searchSection}>
-                <Typography component="h1" variant="body1">
-                  Search Results
-                </Typography>
-                <TableContainer style={{ maxHeight: "350px" }}>
-                  <Table stickyHeader aria-label="sticky results table">
-                    <TableHead>
-                      <TableRow>
-                        <TableCell>First Name</TableCell>
-                        <TableCell>Last Name</TableCell>
-                        <TableCell>Primary Phone Number</TableCell>
-                        <TableCell>Email</TableCell>
-                        <TableCell># of Children</TableCell>
-                      </TableRow>
-                    </TableHead>
-                    {familyResults.length ? (
-                      <TableBody>
-                        {familyResults.map((family) => (
-                          <TableRow>
-                            <TableCell>{family.first_name}</TableCell>
-                            <TableCell>{family.last_name}</TableCell>
-                            <TableCell>{family.phone_number}</TableCell>
-                            <TableCell>{family.email}</TableCell>
-                            <TableCell>{family.num_children}</TableCell>
-                          </TableRow>
-                        ))}
-                      </TableBody>
-                    ) : (
-                      <TableFooter>
-                        <TableRow>
-                          <TableCell
-                            colSpan={5}
-                            style={{ textAlign: "center" }}
-                          >
-                            No Results Found
-                          </TableCell>
-                        </TableRow>
-                      </TableFooter>
-                    )}
-                  </Table>
-                </TableContainer>
-                <Typography
-                  component="h1"
-                  variant="body1"
-                  className={classes.searchSection}
-                >
-                  Not found?
-                </Typography>
+            {displayResults && (
+              <Box marginBottom={1}>
+                <Typography variant="h4">Search results</Typography>
+                <FamilySearchResultsTable families={familyResults} />
+                <Typography variant="h4">Not found?</Typography>
               </Box>
-            ) : null}
+            )}
+            <Button
+              onClick={handleDisplayForm}
+              variant="outlined"
+              className={classes.registerButton}
+            >
+              Register a new client
+            </Button>
           </>
-        ) : null}
-        {displayForm ? (
+        )}
+        {displayForm && (
           <>
             <Button onClick={handleHideForm}>
               <NavigateBefore />
@@ -217,14 +151,6 @@ const RegistrationFormDialog = ({
             </Button>
             <RegistrationForm onSubmit={onFormSubmit} />
           </>
-        ) : (
-          <Button
-            onClick={handleDisplayForm}
-            variant="outlined"
-            style={{ borderRadius: "50px" }}
-          >
-            Register a new client
-          </Button>
         )}
       </DialogContent>
     </Dialog>

--- a/src/components/registration/RegistrationDialog.tsx
+++ b/src/components/registration/RegistrationDialog.tsx
@@ -1,14 +1,23 @@
 import React, { useState } from "react";
 import {
   Button,
+  Box,
   Dialog,
   DialogContent,
   DialogTitle,
   IconButton,
   Typography,
+  TextField,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  TableFooter,
+  TableContainer,
 } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
-import { Close, NavigateBefore } from "@material-ui/icons";
+import { Close, Search, NavigateBefore } from "@material-ui/icons";
 import RegistrationForm from "./RegistrationForm";
 import FamilyAPI, { FamilyStudentRequest } from "../../api/FamilyAPI";
 
@@ -17,6 +26,15 @@ const useStyles = makeStyles((theme) => ({
     position: "absolute",
     right: theme.spacing(1),
     top: theme.spacing(1),
+  },
+  searchSection: {
+    paddingTop: theme.spacing(1),
+    paddingBottom: theme.spacing(1),
+  },
+  searchButton: {
+    height: theme.spacing(5),
+    width: theme.spacing(4),
+    margin: "8px",
   },
 }));
 
@@ -31,13 +49,23 @@ const RegistrationFormDialog = ({
 }: RegistrationFormDialogProps) => {
   const classes = useStyles();
   const [displayForm, setDisplayForm] = useState(false);
+  const [displaySearch, setDisplaySearch] = useState(true);
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [validInput, setValidInput] = useState(true);
+  const [displayResults, setDisplayResults] = useState(false);
+
+  const [familyResponse, setFamilyResponse] = useState<any[]>([]);
 
   const handleDisplayForm = () => {
     setDisplayForm(true);
+    setDisplaySearch(false);
   };
 
   const handleHideForm = () => {
     setDisplayForm(false);
+    setDisplaySearch(true);
   };
 
   const onFormSubmit = async (
@@ -51,6 +79,17 @@ const RegistrationFormDialog = ({
       alert(response.non_field_errors);
     } else {
       handleHideForm();
+    }
+  };
+
+  const onSearchSubmit = async () => {
+    if (firstName || lastName) {
+      setDisplayResults(true);
+      setValidInput(true);
+      setFamilyResponse(await FamilyAPI.getFamilySearch(firstName, lastName));
+    } else {
+      setDisplayResults(false);
+      setValidInput(false);
     }
   };
 
@@ -72,7 +111,98 @@ const RegistrationFormDialog = ({
           <Close />
         </IconButton>
       </DialogTitle>
-      <DialogContent>
+
+      <DialogContent style={{ minHeight: "500px" }}>
+        {displaySearch ? (
+          <>
+            <Typography component="h2" variant="h6">
+              Search for a client
+            </Typography>
+            <Typography component="h1" variant="body1">
+              Make sure the client being registered isn’t already enrolled.
+            </Typography>
+            <Box>
+              <TextField // should these be FormFieldGroup components? Add feature to "wipe" user-entered when dialog closes so that each opening is a clean slate
+                error={!validInput}
+                helperText={validInput ? null : "Please enter a value"}
+                variant="outlined"
+                margin="dense"
+                placeholder="First name"
+                style={{ marginRight: "10px" }}
+                value={firstName}
+                onChange={(e) => setFirstName(e.target.value)}
+              />
+              <TextField
+                error={!validInput}
+                variant="outlined"
+                margin="dense"
+                placeholder="Last name"
+                value={lastName}
+                onChange={(e) => setLastName(e.target.value)}
+              />
+              <Button
+                aria-label="search"
+                variant="contained"
+                color="primary"
+                onClick={onSearchSubmit}
+                className={classes.searchButton}
+              >
+                <Search />
+              </Button>
+            </Box>
+            {displayResults ? (
+              <Box className={classes.searchSection}>
+                <Typography component="h1" variant="body1">
+                  Search Results
+                </Typography>
+                <TableContainer style={{ maxHeight: "350px" }}>
+                  <Table stickyHeader aria-label="sticky results table">
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>First Name</TableCell>
+                        <TableCell>Last Name</TableCell>
+                        <TableCell>Primary Phone Number</TableCell>
+                        <TableCell>Email</TableCell>
+                        <TableCell># of Children</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    {familyResponse.length ? (
+                      <TableBody>
+                        {familyResponse.map((family) => (
+                          <TableRow>
+                            <TableCell>{family.first_name}</TableCell>
+                            <TableCell>{family.last_name}</TableCell>
+                            <TableCell>{family.phone_number}</TableCell>
+                            <TableCell>{family.email}</TableCell>
+                            <TableCell>{family.num_children}</TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    ) : (
+                      <TableFooter>
+                        <TableRow>
+                          <TableCell
+                            colSpan={5}
+                            style={{ textAlign: "center" }}
+                          >
+                            No Results Found
+                          </TableCell>
+                        </TableRow>
+                      </TableFooter>
+                    )}
+                  </Table>
+                </TableContainer>
+                <Typography
+                  component="h1"
+                  variant="body1"
+                  className={classes.searchSection}
+                >
+                  Not found?
+                </Typography>
+              </Box>
+            ) : null}
+          </>
+        ) : null}
         {displayForm ? (
           <>
             <Button onClick={handleHideForm}>
@@ -82,7 +212,13 @@ const RegistrationFormDialog = ({
             <RegistrationForm onSubmit={onFormSubmit} />
           </>
         ) : (
-          <Button onClick={handleDisplayForm}>Register a new client</Button>
+          <Button
+            onClick={handleDisplayForm}
+            variant="outlined"
+            style={{ borderRadius: "50px" }}
+          >
+            Register a new client
+          </Button>
         )}
       </DialogContent>
     </Dialog>

--- a/src/constants/DefaultFields.ts
+++ b/src/constants/DefaultFields.ts
@@ -83,7 +83,7 @@ export const DefaultFields: Record<string, DefaultField> = Object.freeze({
   PHONE_NUMBER: {
     id: DefaultFieldKey.PHONE_NUMBER,
     is_default: true,
-    name: "Phone number",
+    name: "Primary phone number",
     question_type: QuestionTypes.TEXT,
     options: [],
   },

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -81,7 +81,15 @@ const theme = createMuiTheme({
       fontWeight: "bold",
     },
     h2: {
+      fontSize: 34,
+      fontWeight: "bold",
+    },
+    h3: {
       fontSize: 24,
+      fontWeight: "bold",
+    },
+    h4: {
+      fontSize: 16,
       fontWeight: "bold",
     },
   },

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -68,6 +68,19 @@ const theme = createMuiTheme({
         },
       },
     },
+    MuiTableCell: {
+      root: {
+        '& [class*="MuiTableCell-footer"]': {
+          borderBottom: "none",
+        },
+      },
+    },
+    MuiTableContainer: {
+      root: {
+        border: "1px solid",
+        borderColor: defaultTheme.palette.divider,
+      },
+    },
     MuiTabs: {
       root: {
         backgroundColor: "white",


### PR DESCRIPTION
### Notion ticket link

[Search for an existing client by name](https://www.notion.so/uwblueprintexecs/Search-for-an-existing-client-by-name-c9abac8344804d63ba8a9b3ca5f83ef4)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description
- added the family search endpoint & types to FamilyAPI.ts
- created components to allow users to enter and search by parent name (StudentSearchBar) and retrieve a table of results (FamilySearchResultsTable)
  - these components will be reused for the "Add a guest" modal later, which is functionally & visually quite similar
- unit tests will be added in an upcoming PR

<img width="1261" alt="Screen Shot 2021-06-25 at 10 33 58 PM" src="https://user-images.githubusercontent.com/37346399/123499542-90f3a800-d605-11eb-9d2d-9e5fde50aea3.png">
<img width="1262" alt="Screen Shot 2021-06-25 at 10 34 17 PM" src="https://user-images.githubusercontent.com/37346399/123499536-89cc9a00-d605-11eb-8faa-50956089ded6.png">


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. open the deploy preview
2. go to the sessions page and click "Add a client"
3. search by the first and/or last name of a parent in the db, and verify that results appear
4. search by a first/last name that **does not** exist in the db, and verify that the table displays "No results found"
5. search with no first/last name, and verify that the input boxes highlight with a message "Please enter a value"
6. when leaving the search page (closing dialog, going to reg form, etc.) and returning, the search form & results should be a blank slate

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- code quality
- manual testing functionality

### Checklist

- [X] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [X] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
