### PR TITLE
Show only the selected session's fields in the registration form

### DIFF
--- a/src/components/registration/RegistrationDialog.tsx
+++ b/src/components/registration/RegistrationDialog.tsx
@@ -9,11 +9,12 @@ import {
 } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import { Close, NavigateBefore } from "@material-ui/icons";
-import RegistrationForm from "./RegistrationForm";
+import RegistrationForm from "./registration-form";
 import FamilyAPI, {
   FamilySearchResponse,
   FamilyStudentRequest,
 } from "../../api/FamilyAPI";
+import { SessionDetailResponse } from "../../api/SessionAPI";
 import FamilySearchResultsTable from "../family-search/family-search-results-table";
 import StudentSearchBar from "../family-search/student-search-bar";
 
@@ -41,15 +42,13 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-type RegistrationFormDialogProps = {
+type Props = {
   open: boolean;
   onClose: () => void;
+  session: SessionDetailResponse;
 };
 
-const RegistrationFormDialog = ({
-  open,
-  onClose,
-}: RegistrationFormDialogProps) => {
+const RegistrationDialog = ({ open, onClose, session }: Props) => {
   const classes = useStyles();
   const [shouldDisplaySearch, setShouldDisplaySearch] = useState(true);
   const [firstName, setFirstName] = useState("");
@@ -153,7 +152,10 @@ const RegistrationFormDialog = ({
               <NavigateBefore />
               Go back
             </Button>
-            <RegistrationForm onSubmit={onRegistrationFormSubmit} />
+            <RegistrationForm
+              onSubmit={onRegistrationFormSubmit}
+              session={session}
+            />
           </>
         )}
       </DialogContent>
@@ -161,4 +163,4 @@ const RegistrationFormDialog = ({
   );
 };
 
-export default RegistrationFormDialog;
+export default RegistrationDialog;

--- a/src/components/registration/registration-form/RegistrationForm.tsx
+++ b/src/components/registration/registration-form/RegistrationForm.tsx
@@ -1,19 +1,21 @@
 import React, { useContext, useState } from "react";
 import { Button, Typography } from "@material-ui/core";
-import { DynamicFieldsContext } from "../../context/DynamicFieldsContext";
-import FormFieldGroup from "./FormFieldGroup";
+import { DynamicFieldsContext } from "../../../context/DynamicFieldsContext";
+import FormFieldGroup from "../FormFieldGroup";
 import {
   DefaultFamilyFormFields,
   DefaultStudentFormFields,
-} from "../../constants/DefaultFields";
-import StudentRole from "../../constants/StudentRole";
+} from "../../../constants/DefaultFields";
+import StudentRole from "../../../constants/StudentRole";
 import {
   FamilyRequest,
   FamilyStudentRequest,
   StudentRequest,
-} from "../../api/FamilyAPI";
-import { DefaultFormField } from "../../hooks/useFormFields";
-import DefaultFieldKey from "../../constants/DefaultFieldKey";
+} from "../../../api/FamilyAPI";
+import { DefaultFormField } from "../../../hooks/useFormFields";
+import DefaultFieldKey from "../../../constants/DefaultFieldKey";
+import { SessionDetailResponse } from "../../../api/SessionAPI";
+import { DynamicField } from "../../../types";
 
 export enum TestId {
   ChildrenDefaultFields = "children-default-fields",
@@ -24,6 +26,7 @@ export enum TestId {
   ParentDefaultFields = "parent-default-fields",
   ParentDynamicFields = "parent-dynamic-fields",
   RegistrationForm = "registration-form",
+  SessionLabel = "session-label",
 }
 
 const defaultFamilyRequestData: FamilyRequest = {
@@ -47,9 +50,10 @@ type RegistrationFormProps = {
     e: React.FormEvent<HTMLFormElement>,
     data: FamilyStudentRequest
   ) => void;
+  session: SessionDetailResponse;
 };
 
-const RegistrationForm = ({ onSubmit }: RegistrationFormProps) => {
+const RegistrationForm = ({ onSubmit, session }: RegistrationFormProps) => {
   const {
     childDynamicFields,
     guestDynamicFields,
@@ -81,6 +85,11 @@ const RegistrationForm = ({ onSubmit }: RegistrationFormProps) => {
       role: StudentRole.PARENT,
     }));
 
+  const getSessionDynamicFields = (dynamicFields: DynamicField[]) =>
+    dynamicFields.filter((dynamicField) =>
+      session.fields.includes(dynamicField.id)
+    );
+
   const getSubmissionData = (): FamilyStudentRequest => ({
     ...familyData,
     parent: { ...parentData },
@@ -93,8 +102,11 @@ const RegistrationForm = ({ onSubmit }: RegistrationFormProps) => {
       data-testid={TestId.RegistrationForm}
       onSubmit={(e) => onSubmit(e, getSubmissionData())}
     >
-      <Typography variant="body1">
-        Currently enrolling a <b>new family</b> for <b>the latest session</b>
+      <Typography variant="body1" data-testid={TestId.SessionLabel}>
+        Currently enrolling a <b>new family</b> for{" "}
+        <b>
+          {session.season} {session.year}
+        </b>
       </Typography>
 
       <Typography component="h3" variant="h5">
@@ -112,7 +124,7 @@ const RegistrationForm = ({ onSubmit }: RegistrationFormProps) => {
       />
       <FormFieldGroup
         testId={TestId.ParentDynamicFields}
-        fields={parentDynamicFields}
+        fields={getSessionDynamicFields(parentDynamicFields)}
         onChange={(data) =>
           setParentData(
             Object.assign(parentData, { ...parentData, information: data })
@@ -130,7 +142,7 @@ const RegistrationForm = ({ onSubmit }: RegistrationFormProps) => {
       />
       <FormFieldGroup
         testId={TestId.ChildrenDynamicFields}
-        fields={childDynamicFields}
+        fields={getSessionDynamicFields(childDynamicFields)}
         onChange={(data) =>
           setChildData(
             Object.assign(childData, { ...childData, information: data })
@@ -148,7 +160,7 @@ const RegistrationForm = ({ onSubmit }: RegistrationFormProps) => {
       />
       <FormFieldGroup
         testId={TestId.GuestsDynamicFields}
-        fields={guestDynamicFields}
+        fields={getSessionDynamicFields(guestDynamicFields)}
         onChange={(data) =>
           setGuestData(
             Object.assign(guestData, { ...guestData, information: data })

--- a/src/components/registration/registration-form/index.ts
+++ b/src/components/registration/registration-form/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RegistrationForm";

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -165,6 +165,7 @@ const Sessions = () => {
             <RegistrationDialog
               open={displayRegDialog}
               onClose={handleCloseFormDialog}
+              session={selectedSession}
             />
           </>
         )}


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Make registration form session-specific](https://www.notion.so/uwblueprintexecs/Sprint-1-7d96db8183464ed88641c14260383b52?p=79907934293249e185776a1a110626d7)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- pass the selected session from the sessions page to the reg form component
- render only the dynamic fields that are in `sessions.fields`
- update tests

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. yarn test

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

🧼🛁 🧽 

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
