### PR TITLE
Allow registering multiple children & guests (Implementation)

### DIFF
--- a/src/components/families/family-form/FamilyForm.tsx
+++ b/src/components/families/family-form/FamilyForm.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Button, Typography } from "@material-ui/core";
+import { Typography } from "@material-ui/core";
 
 import { FamilyDetailResponse, FamilyRequest, StudentRequest } from "api/types";
 import DefaultFieldKey from "constants/DefaultFieldKey";
@@ -19,7 +19,7 @@ export enum TestId {
   SessionLabel = "session-label",
 }
 
-export type FamilyStudentFormData = FamilyRequest & {
+export type FamilyFormData = FamilyRequest & {
   children: StudentFormData[];
   guests: StudentFormData[];
   parent: StudentRequest;
@@ -50,7 +50,7 @@ const studentRequestToStudentFormData = (
 
 export const familyResponseToFamilyFormData = (
   family: FamilyDetailResponse
-): FamilyStudentFormData => ({
+): FamilyFormData => ({
   ...family,
   children: family.children.map((child) =>
     studentRequestToStudentFormData(child, StudentRole.CHILD)
@@ -68,11 +68,11 @@ export const studentFormDataToStudentRequest = (
 };
 
 type Props = {
-  family: FamilyStudentFormData;
+  family: FamilyFormData;
   childDynamicFields: DynamicField[];
   guestDynamicFields: DynamicField[];
   parentDynamicFields: DynamicField[];
-  onChange: (family: FamilyStudentFormData) => void;
+  onChange: (family: FamilyFormData) => void;
 };
 
 const FamilyForm = ({
@@ -82,9 +82,7 @@ const FamilyForm = ({
   parentDynamicFields,
   onChange,
 }: Props) => {
-  const handleAddStudent = (
-    role: StudentRole.GUEST | StudentRole.CHILD
-  ): void => {
+  const addStudent = (role: StudentRole.GUEST | StudentRole.CHILD): void => {
     if (role === StudentRole.CHILD) {
       onChange({
         ...family,
@@ -119,7 +117,7 @@ const FamilyForm = ({
     }
   };
 
-  const handleDeleteStudent = (
+  const deleteStudent = (
     index: number,
     role: StudentRole.CHILD | StudentRole.GUEST
   ): void => {
@@ -148,28 +146,28 @@ const FamilyForm = ({
       </Typography>
       <StudentForm
         dynamicFields={childDynamicFields}
-        studentData={family.children}
-        updateStudent={updateStudent}
-        handleDeleteStudent={handleDeleteStudent}
+        onAddStudent={() => addStudent(StudentRole.CHILD)}
+        onDeleteStudent={(id) => deleteStudent(id, StudentRole.CHILD)}
+        onUpdateStudent={(id, data) =>
+          updateStudent(id, data, StudentRole.CHILD)
+        }
         role={StudentRole.CHILD}
+        students={family.children}
       />
-      <Button onClick={() => handleAddStudent(StudentRole.CHILD)}>
-        Add Child
-      </Button>
 
       <Typography component="h3" variant="h5">
         Family members
       </Typography>
       <StudentForm
         dynamicFields={guestDynamicFields}
-        studentData={family.guests}
-        updateStudent={updateStudent}
-        handleDeleteStudent={handleDeleteStudent}
+        onAddStudent={() => addStudent(StudentRole.GUEST)}
+        onDeleteStudent={(id) => deleteStudent(id, StudentRole.GUEST)}
+        onUpdateStudent={(id, data) =>
+          updateStudent(id, data, StudentRole.GUEST)
+        }
         role={StudentRole.GUEST}
+        students={family.guests}
       />
-      <Button onClick={() => handleAddStudent(StudentRole.GUEST)}>
-        Add Family Member
-      </Button>
     </>
   );
 };

--- a/src/components/families/family-form/FamilyForm.tsx
+++ b/src/components/families/family-form/FamilyForm.tsx
@@ -1,25 +1,78 @@
 import React from "react";
 
-import { Typography } from "@material-ui/core";
+import { Button, Typography } from "@material-ui/core";
 
-import { FamilyStudentRequest } from "api/types";
+import { FamilyDetailResponse, FamilyRequest, StudentRequest } from "api/types";
+import DefaultFieldKey from "constants/DefaultFieldKey";
 import StudentRole from "constants/StudentRole";
 import { DynamicField } from "types";
 
 import FamilyParentFields from "./family-parent-fields";
-import StudentFields from "./student-fields";
+import StudentForm, { StudentFormData } from "./student-form";
+
+// unique identifier for children form components
+let CHILD_KEY_COUNTER = 1;
+let GUEST_KEY_COUNTER = 1;
 
 export enum TestId {
   RegistrationForm = "registration-form",
   SessionLabel = "session-label",
 }
 
+export type FamilyStudentFormData = FamilyRequest & {
+  children: StudentFormData[];
+  guests: StudentFormData[];
+  parent: StudentRequest;
+};
+
+const defaultStudentData: StudentRequest = {
+  [DefaultFieldKey.FIRST_NAME]: "",
+  [DefaultFieldKey.LAST_NAME]: "",
+  information: {},
+};
+
+const generateKey = (role: StudentRole.CHILD | StudentRole.GUEST): number => {
+  let key = 0;
+  if (role === StudentRole.CHILD) {
+    key = CHILD_KEY_COUNTER;
+    CHILD_KEY_COUNTER += 1;
+  } else if (role === StudentRole.GUEST) {
+    key = GUEST_KEY_COUNTER;
+    GUEST_KEY_COUNTER += 1;
+  }
+  return key;
+};
+
+const studentRequestToStudentFormData = (
+  student: StudentRequest,
+  role: StudentRole.CHILD | StudentRole.GUEST
+): StudentFormData => ({ ...student, index: generateKey(role) });
+
+export const familyResponseToFamilyFormData = (
+  family: FamilyDetailResponse
+): FamilyStudentFormData => ({
+  ...family,
+  children: family.children.map((child) =>
+    studentRequestToStudentFormData(child, StudentRole.CHILD)
+  ),
+  guests: family.guests.map((guest) =>
+    studentRequestToStudentFormData(guest, StudentRole.GUEST)
+  ),
+});
+
+export const studentFormDataToStudentRequest = (
+  obj: StudentFormData
+): StudentRequest => {
+  const { index, ...req } = obj;
+  return req as StudentRequest;
+};
+
 type Props = {
-  family: FamilyStudentRequest;
+  family: FamilyStudentFormData;
   childDynamicFields: DynamicField[];
   guestDynamicFields: DynamicField[];
   parentDynamicFields: DynamicField[];
-  onChange: (family: FamilyStudentRequest) => void;
+  onChange: (family: FamilyStudentFormData) => void;
 };
 
 const FamilyForm = ({
@@ -28,47 +81,97 @@ const FamilyForm = ({
   guestDynamicFields,
   parentDynamicFields,
   onChange,
-}: Props) => (
-  <>
-    <Typography component="h3" variant="h5">
-      Basic information
-    </Typography>
-    <FamilyParentFields
-      dynamicFields={parentDynamicFields}
-      family={family}
-      onChange={(value) => onChange({ ...family, ...value })}
-    />
+}: Props) => {
+  const handleAddStudent = (
+    role: StudentRole.GUEST | StudentRole.CHILD
+  ): void => {
+    if (role === StudentRole.CHILD) {
+      onChange({
+        ...family,
+        children: [
+          ...family.children,
+          { ...defaultStudentData, index: generateKey(role) },
+        ],
+      });
+    } else {
+      onChange({
+        ...family,
+        guests: [
+          ...family.guests,
+          { ...defaultStudentData, index: generateKey(role) },
+        ],
+      });
+    }
+  };
 
-    <Typography component="h3" variant="h5">
-      Children
-    </Typography>
-    <StudentFields
-      dynamicFields={childDynamicFields}
-      onChange={(value) =>
-        onChange({
-          ...family,
-          children: [{ ...family.children[0], ...value }],
-        })
-      }
-      role={StudentRole.CHILD}
-      student={family.children[0]}
-    />
+  const updateStudent = (
+    index: number,
+    data: StudentRequest,
+    role: StudentRole.GUEST | StudentRole.CHILD
+  ): void => {
+    const students =
+      role === StudentRole.CHILD ? [...family.children] : [...family.guests];
+    students[index] = { ...students[index], ...data };
+    if (role === StudentRole.CHILD) {
+      onChange({ ...family, children: students });
+    } else {
+      onChange({ ...family, guests: students });
+    }
+  };
 
-    <Typography component="h3" variant="h5">
-      Family members
-    </Typography>
-    <StudentFields
-      dynamicFields={guestDynamicFields}
-      onChange={(value) =>
-        onChange({
-          ...family,
-          guests: [{ ...family.guests[0], ...value }],
-        })
-      }
-      role={StudentRole.GUEST}
-      student={family.guests[0]}
-    />
-  </>
-);
+  const handleDeleteStudent = (
+    index: number,
+    role: StudentRole.CHILD | StudentRole.GUEST
+  ): void => {
+    const data = role === StudentRole.CHILD ? family.children : family.guests;
+    const students = data.filter((e) => e.index !== index);
+    if (role === StudentRole.CHILD) {
+      onChange({ ...family, children: [...students] });
+    } else {
+      onChange({ ...family, guests: [...students] });
+    }
+  };
+
+  return (
+    <>
+      <Typography component="h3" variant="h5" style={{ marginBottom: 16 }}>
+        Basic information
+      </Typography>
+      <FamilyParentFields
+        dynamicFields={parentDynamicFields}
+        family={family}
+        onChange={(value) => onChange({ ...family, ...value })}
+      />
+
+      <Typography component="h3" variant="h5">
+        Children
+      </Typography>
+      <StudentForm
+        dynamicFields={childDynamicFields}
+        studentData={family.children}
+        updateStudent={updateStudent}
+        handleDeleteStudent={handleDeleteStudent}
+        role={StudentRole.CHILD}
+      />
+      <Button onClick={() => handleAddStudent(StudentRole.CHILD)}>
+        Add Child
+      </Button>
+
+      <Typography component="h3" variant="h5">
+        Family members
+      </Typography>
+      <StudentForm
+        dynamicFields={guestDynamicFields}
+        studentData={family.guests}
+        updateStudent={updateStudent}
+        handleDeleteStudent={handleDeleteStudent}
+        role={StudentRole.GUEST}
+      />
+      <Button onClick={() => handleAddStudent(StudentRole.GUEST)}>
+        Add Family Member
+      </Button>
+    </>
+  );
+};
 
 export default FamilyForm;

--- a/src/components/families/family-form/FamilyForm.tsx
+++ b/src/components/families/family-form/FamilyForm.tsx
@@ -121,12 +121,14 @@ const FamilyForm = ({
     index: number,
     role: StudentRole.CHILD | StudentRole.GUEST
   ): void => {
-    const data = role === StudentRole.CHILD ? family.children : family.guests;
-    const students = data.filter((e) => e.index !== index);
+    const students = (role === StudentRole.CHILD
+      ? [...family.children]
+      : [...family.guests]
+    ).filter((e) => e.index !== index);
     if (role === StudentRole.CHILD) {
-      onChange({ ...family, children: [...students] });
+      onChange({ ...family, children: students });
     } else {
-      onChange({ ...family, guests: [...students] });
+      onChange({ ...family, guests: students });
     }
   };
 

--- a/src/components/families/family-form/index.ts
+++ b/src/components/families/family-form/index.ts
@@ -1,1 +1,6 @@
-export { default } from "./FamilyForm";
+export {
+  default,
+  familyResponseToFamilyFormData,
+  studentFormDataToStudentRequest,
+} from "./FamilyForm";
+export type { FamilyStudentFormData } from "./FamilyForm";

--- a/src/components/families/family-form/index.ts
+++ b/src/components/families/family-form/index.ts
@@ -3,4 +3,4 @@ export {
   familyResponseToFamilyFormData,
   studentFormDataToStudentRequest,
 } from "./FamilyForm";
-export type { FamilyStudentFormData } from "./FamilyForm";
+export type { FamilyFormData } from "./FamilyForm";

--- a/src/components/families/family-form/student-form/StudentForm.tsx
+++ b/src/components/families/family-form/student-form/StudentForm.tsx
@@ -19,47 +19,43 @@ export type StudentFormData = StudentRequest & { index: number };
 
 type Props = {
   dynamicFields: DynamicField[];
-  studentData: StudentFormData[];
-  updateStudent: (
-    id: number,
-    data: StudentRequest,
-    role: StudentRole.CHILD | StudentRole.GUEST
-  ) => void;
-  handleDeleteStudent: (
-    id: number,
-    role: StudentRole.CHILD | StudentRole.GUEST
-  ) => void;
+  onAddStudent: () => void;
+  onDeleteStudent: (id: number) => void;
+  onUpdateStudent: (id: number, data: StudentRequest) => void;
   role: StudentRole.CHILD | StudentRole.GUEST;
+  students: StudentFormData[];
 };
 
 const StudentForm = ({
   dynamicFields,
-  studentData,
-  updateStudent,
-  handleDeleteStudent,
+  onAddStudent,
+  onDeleteStudent,
+  onUpdateStudent,
   role,
+  students,
 }: Props) => {
   const roleName = role === StudentRole.CHILD ? "Child" : "Family Member";
   return (
     <>
-      {studentData.map((student, i) => (
+      {students.map((student, i) => (
         <div key={student.index}>
           <Typography component="h4" variant="h6">
             {roleName} {i + 1}
           </Typography>
-          {(role === StudentRole.GUEST || studentData.length > 1) && (
-            <Button onClick={() => handleDeleteStudent(student.index, role)}>
+          {(role === StudentRole.GUEST || students.length > 1) && (
+            <Button onClick={() => onDeleteStudent(student.index)}>
               Delete {roleName}
             </Button>
           )}
           <StudentFields
             dynamicFields={dynamicFields}
-            onChange={(data) => updateStudent(i, data, role)}
+            onChange={(data) => onUpdateStudent(i, data)}
             role={role}
             student={student}
           />
         </div>
       ))}
+      <Button onClick={onAddStudent}>Add {roleName}</Button>
     </>
   );
 };

--- a/src/components/families/family-form/student-form/StudentForm.tsx
+++ b/src/components/families/family-form/student-form/StudentForm.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+
+import { Button, Typography } from "@material-ui/core";
+
+import { StudentRequest } from "api/types";
+import StudentRole from "constants/StudentRole";
+import { DynamicField } from "types";
+
+import StudentFields from "../student-fields";
+
+export enum TestId {
+  ChildrenDefaultFields = "children-default-fields",
+  ChildrenDynamicFields = "children-dynamic-fields",
+  GuestsDefaultFields = "guests-default-fields",
+  GuestsDynamicFields = "guests-dynamic-fields",
+}
+
+export type StudentFormData = StudentRequest & { index: number };
+
+type Props = {
+  dynamicFields: DynamicField[];
+  studentData: StudentFormData[];
+  updateStudent: (
+    id: number,
+    data: StudentRequest,
+    role: StudentRole.CHILD | StudentRole.GUEST
+  ) => void;
+  handleDeleteStudent: (
+    id: number,
+    role: StudentRole.CHILD | StudentRole.GUEST
+  ) => void;
+  role: StudentRole.CHILD | StudentRole.GUEST;
+};
+
+const StudentForm = ({
+  dynamicFields,
+  studentData,
+  updateStudent,
+  handleDeleteStudent,
+  role,
+}: Props) => {
+  const roleName = role === StudentRole.CHILD ? "Child" : "Family Member";
+  return (
+    <>
+      {studentData.map((student, i) => (
+        <div key={student.index}>
+          <Typography component="h4" variant="h6">
+            {roleName} {i + 1}
+          </Typography>
+          {(role === StudentRole.GUEST || studentData.length > 1) && (
+            <Button onClick={() => handleDeleteStudent(student.index, role)}>
+              Delete {roleName}
+            </Button>
+          )}
+          <StudentFields
+            dynamicFields={dynamicFields}
+            onChange={(data) => updateStudent(i, data, role)}
+            role={role}
+            student={student}
+          />
+        </div>
+      ))}
+    </>
+  );
+};
+
+export default StudentForm;

--- a/src/components/families/family-form/student-form/StudentForm.tsx
+++ b/src/components/families/family-form/student-form/StudentForm.tsx
@@ -8,13 +8,6 @@ import { DynamicField } from "types";
 
 import StudentFields from "../student-fields";
 
-export enum TestId {
-  ChildrenDefaultFields = "children-default-fields",
-  ChildrenDynamicFields = "children-dynamic-fields",
-  GuestsDefaultFields = "guests-default-fields",
-  GuestsDynamicFields = "guests-dynamic-fields",
-}
-
 export type StudentFormData = StudentRequest & { index: number };
 
 type Props = {

--- a/src/components/families/family-form/student-form/index.ts
+++ b/src/components/families/family-form/student-form/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./StudentForm";
+export type { StudentFormData } from "./StudentForm";

--- a/src/components/registration/registration-form/RegistrationForm.tsx
+++ b/src/components/registration/registration-form/RegistrationForm.tsx
@@ -8,7 +8,7 @@ import {
   SessionDetailResponse,
 } from "api/types";
 import FamilyForm, {
-  FamilyStudentFormData,
+  FamilyFormData,
   studentFormDataToStudentRequest,
 } from "components/families/family-form";
 import DefaultFieldKey from "constants/DefaultFieldKey";
@@ -26,7 +26,7 @@ const defaultStudentData: StudentRequest = {
   information: {},
 };
 
-const defaultFamilyData: FamilyStudentFormData = {
+const defaultFamilyData: FamilyFormData = {
   [DefaultFieldKey.ADDRESS]: "",
   [DefaultFieldKey.CELL_NUMBER]: "",
   [DefaultFieldKey.EMAIL]: "",
@@ -54,9 +54,7 @@ const RegistrationForm = ({ onSubmit, session }: RegistrationFormProps) => {
     parentDynamicFields,
   } = useContext(DynamicFieldsContext);
 
-  const [family, setFamily] = useState<FamilyStudentFormData>(
-    defaultFamilyData
-  );
+  const [family, setFamily] = useState<FamilyFormData>(defaultFamilyData);
 
   const getSessionDynamicFields = (dynamicFields: DynamicField[]) =>
     dynamicFields.filter((dynamicField) =>

--- a/src/components/registration/registration-form/RegistrationForm.tsx
+++ b/src/components/registration/registration-form/RegistrationForm.tsx
@@ -7,7 +7,10 @@ import {
   StudentRequest,
   SessionDetailResponse,
 } from "api/types";
-import FamilyForm from "components/families/family-form";
+import FamilyForm, {
+  FamilyStudentFormData,
+  studentFormDataToStudentRequest,
+} from "components/families/family-form";
 import DefaultFieldKey from "constants/DefaultFieldKey";
 import { DynamicFieldsContext } from "context/DynamicFieldsContext";
 import { DynamicField } from "types";
@@ -23,7 +26,7 @@ const defaultStudentData: StudentRequest = {
   information: {},
 };
 
-const defaultFamilyData: FamilyStudentRequest = {
+const defaultFamilyData: FamilyStudentFormData = {
   [DefaultFieldKey.ADDRESS]: "",
   [DefaultFieldKey.CELL_NUMBER]: "",
   [DefaultFieldKey.EMAIL]: "",
@@ -32,8 +35,8 @@ const defaultFamilyData: FamilyStudentRequest = {
   [DefaultFieldKey.PREFERRED_NUMBER]: "",
   [DefaultFieldKey.WORK_NUMBER]: "",
   parent: { ...defaultStudentData },
-  children: [{ ...defaultStudentData }],
-  guests: [{ ...defaultStudentData }],
+  children: [{ ...defaultStudentData, index: 0 }],
+  guests: [],
 };
 
 type RegistrationFormProps = {
@@ -51,17 +54,29 @@ const RegistrationForm = ({ onSubmit, session }: RegistrationFormProps) => {
     parentDynamicFields,
   } = useContext(DynamicFieldsContext);
 
-  const [family, setFamily] = useState<FamilyStudentRequest>(defaultFamilyData);
+  const [family, setFamily] = useState<FamilyStudentFormData>(
+    defaultFamilyData
+  );
 
   const getSessionDynamicFields = (dynamicFields: DynamicField[]) =>
     dynamicFields.filter((dynamicField) =>
       session.fields.includes(dynamicField.id)
     );
 
+  const getSubmissionData = (): FamilyStudentRequest => ({
+    ...family,
+    children: family.children.map((child) =>
+      studentFormDataToStudentRequest(child)
+    ),
+    guests: family.guests.map((guest) =>
+      studentFormDataToStudentRequest(guest)
+    ),
+  });
+
   return (
     <form
       data-testid={TestId.RegistrationForm}
-      onSubmit={(e) => onSubmit(e, family)}
+      onSubmit={(e) => onSubmit(e, getSubmissionData())}
     >
       <Typography variant="body1" data-testid={TestId.SessionLabel}>
         Currently enrolling a <b>new family</b> for{" "}

--- a/src/components/registration/registration-form/RegistrationForm.unit.test.tsx
+++ b/src/components/registration/registration-form/RegistrationForm.unit.test.tsx
@@ -231,6 +231,7 @@ describe("when text fields are submitted", () => {
     );
 
     // guest section
+    fireEvent.click(getByRole("button", { name: "Add Guest" }));
     fireEvent.change(
       getByTestId(`${StudentRole.GUEST} ${DefaultFields.FIRST_NAME.name}`),
       {

--- a/src/components/registration/registration-form/RegistrationForm.unit.test.tsx
+++ b/src/components/registration/registration-form/RegistrationForm.unit.test.tsx
@@ -231,7 +231,7 @@ describe("when text fields are submitted", () => {
     );
 
     // guest section
-    fireEvent.click(getByRole("button", { name: "Add Guest" }));
+    fireEvent.click(getByRole("button", { name: "Add Family Member" }));
     fireEvent.change(
       getByTestId(`${StudentRole.GUEST} ${DefaultFields.FIRST_NAME.name}`),
       {


### PR DESCRIPTION
### Notion ticket link


[Allow registering multiple children & guests](https://www.notion.so/uwblueprintexecs/Allow-registering-multiple-children-guests-new-registrant-aaeb812d2afc4b99b8efd13ea136ec1d)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- Created new components for Children and Guest Registration forms
- Added some extra functions to support tracking/modifying multiple children/guests

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. "Add a client" on the session screen
2.  Adding new children and new guests should add to the form
3. Deleting the child should only delete the specified data

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- The session registration form
