### PR TITLE
Implement "Create a session" step

### DIFF
--- a/src/components/common/date-input/DateInput.tsx
+++ b/src/components/common/date-input/DateInput.tsx
@@ -1,10 +1,15 @@
 import React from "react";
 
 import { Box, InputLabel } from "@material-ui/core";
-import { DatePicker } from "@material-ui/pickers";
+import { KeyboardDatePicker } from "@material-ui/pickers";
 import moment from "moment";
 
 import { InputProps } from "types";
+
+export enum TestId {
+  Input = "input",
+  KeyboardButton = "keyboard-button",
+}
 
 type Props = InputProps & {
   value: Date;
@@ -17,15 +22,20 @@ const DateInput = ({ id, label, value, onChange, inputWidth }: Props) => (
       <InputLabel htmlFor={id}>{label}</InputLabel>
     </Box>
     <Box width={inputWidth}>
-      <DatePicker
+      <KeyboardDatePicker
         id={id}
         autoOk
         disableToolbar
         variant="inline"
         inputVariant="outlined"
-        format="MMMM D, yyyy"
+        format="MM/DD/yyyy"
         value={value}
         onChange={(date) => onChange(moment(date).toDate())}
+        KeyboardButtonProps={{
+          "aria-label": "change date",
+          ...{ "data-testid": TestId.KeyboardButton },
+        }}
+        inputProps={{ "data-testid": TestId.Input }}
         fullWidth
       />
     </Box>

--- a/src/components/common/date-input/index.ts
+++ b/src/components/common/date-input/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DateInput";

--- a/src/components/sessions/session-config/SessionConfig.tsx
+++ b/src/components/sessions/session-config/SessionConfig.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+
+import { Typography } from "@material-ui/core";
+
+import DateInput from "components/common/date-input";
+import TextInput from "components/common/inputs/TextInput";
+
+const FORM_FIELD_WIDTH = 328;
+
+export enum TestId {
+  NameInput = "name-input",
+}
+
+type Props = {
+  sessionName: string;
+  onChangeSessionName: (name: string) => void;
+  startDate: Date;
+  onChangeStartDate: (date: Date) => void;
+};
+
+const SessionConfig = ({
+  sessionName,
+  onChangeSessionName,
+  startDate,
+  onChangeStartDate,
+}: Props) => (
+  <div>
+    <Typography variant="h2">Session information</Typography>
+    <TextInput
+      testId={TestId.NameInput}
+      id="session-name"
+      label="Name"
+      value={sessionName}
+      onChange={(name) => onChangeSessionName(name)}
+      inputWidth={FORM_FIELD_WIDTH}
+    />
+    <DateInput
+      id="start-date"
+      label="Start date"
+      value={startDate}
+      onChange={(date) => onChangeStartDate(date)}
+      inputWidth={FORM_FIELD_WIDTH}
+    />
+  </div>
+);
+
+export default SessionConfig;

--- a/src/components/sessions/session-config/SessionConfig.tsx
+++ b/src/components/sessions/session-config/SessionConfig.tsx
@@ -9,6 +9,7 @@ const FORM_FIELD_WIDTH = 328;
 
 export enum TestId {
   NameInput = "name-input",
+  SessionConfig = "session-config",
 }
 
 type Props = {
@@ -24,7 +25,7 @@ const SessionConfig = ({
   startDate,
   onChangeStartDate,
 }: Props) => (
-  <div>
+  <div data-testid={TestId.SessionConfig}>
     <Typography variant="h2">Session information</Typography>
     <TextInput
       testId={TestId.NameInput}

--- a/src/components/sessions/session-config/SessionConfig.unit.test.tsx
+++ b/src/components/sessions/session-config/SessionConfig.unit.test.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+
+import MomentUtils from "@date-io/moment";
+import { MuiPickersUtilsProvider } from "@material-ui/pickers";
+import { fireEvent, render } from "@testing-library/react";
+
+import { TestId as DateInputTestId } from "components/common/date-input/DateInput";
+
+import SessionConfig, { TestId } from "./SessionConfig";
+
+describe("SessionConfig", () => {
+  let getByTestId: any;
+  let getByText: any;
+  const onChangeSessionName = jest.fn();
+  const onChangeStartDate = jest.fn();
+
+  beforeEach(() => {
+    ({ getByTestId, getByText } = render(
+      <MuiPickersUtilsProvider utils={MomentUtils}>
+        <SessionConfig
+          sessionName="Fall 2020"
+          onChangeSessionName={onChangeSessionName}
+          startDate={new Date(2020, 9, 1)}
+          onChangeStartDate={onChangeStartDate}
+        />
+      </MuiPickersUtilsProvider>
+    ));
+  });
+
+  it("renders the page title", () => {
+    expect(getByText("Session information")).toBeInTheDocument();
+  });
+
+  it("displays the session name in the name input", async () => {
+    expect(getByTestId(TestId.NameInput)).toHaveValue("Fall 2020");
+  });
+
+  it("updates the name when the name is edited", async () => {
+    await fireEvent.change(getByTestId(TestId.NameInput), {
+      target: { value: "Fall 2020 - GSL for Families" },
+    });
+    expect(onChangeSessionName).toHaveBeenCalledTimes(1);
+    expect(onChangeSessionName).toHaveBeenCalledWith(
+      "Fall 2020 - GSL for Families"
+    );
+  });
+
+  it("displays the start date in the date input", async () => {
+    expect(getByTestId(DateInputTestId.Input)).toHaveValue("10/01/2020");
+  });
+
+  it("updates the start date when a new date is picked", async () => {
+    await fireEvent.click(getByTestId(DateInputTestId.KeyboardButton));
+    await fireEvent.click(await getByText("2"));
+    expect(onChangeStartDate).toHaveBeenCalledTimes(1);
+    expect(onChangeStartDate).toHaveBeenCalledWith(new Date(2020, 9, 2));
+  });
+});

--- a/src/components/sessions/session-config/index.ts
+++ b/src/components/sessions/session-config/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SessionConfig";

--- a/src/pages/create-session/CreateSession.tsx
+++ b/src/pages/create-session/CreateSession.tsx
@@ -11,6 +11,8 @@ import {
 import { NavigateBefore } from "@material-ui/icons";
 import { useHistory } from "react-router-dom";
 
+import SessionConfig from "components/sessions/session-config";
+
 enum CreateSessionStepLabel {
   ADD_CLASSES = "Add classes",
   CONFIGURE_FORM = "Configure form",
@@ -25,7 +27,7 @@ const steps = [
 
 const CreateSession = () => {
   const history = useHistory();
-  const [session] = useState({
+  const [session, setSession] = useState({
     name: "",
     startDate: new Date(),
   });
@@ -60,7 +62,27 @@ const CreateSession = () => {
     [CreateSessionStepLabel.CONFIGURE_SESSION]: "Create a new session",
   };
 
-  const stepContent = () => null;
+  const stepContent = () => {
+    switch (activeStep) {
+      case CreateSessionStepLabel.CONFIGURE_SESSION:
+        return (
+          <SessionConfig
+            sessionName={session.name}
+            onChangeSessionName={(name) => setSession({ ...session, name })}
+            startDate={session.startDate}
+            onChangeStartDate={(startDate) =>
+              setSession({ ...session, startDate })
+            }
+          />
+        );
+      case CreateSessionStepLabel.CONFIGURE_FORM:
+      // fall through
+      case CreateSessionStepLabel.ADD_CLASSES:
+      // fall through
+      default:
+        return null;
+    }
+  };
 
   return (
     <div>

--- a/src/pages/create-session/CreateSession.unit.test.tsx
+++ b/src/pages/create-session/CreateSession.unit.test.tsx
@@ -4,13 +4,16 @@ import MomentUtils from "@date-io/moment";
 import { MuiPickersUtilsProvider } from "@material-ui/pickers";
 import { fireEvent, render } from "@testing-library/react";
 
+import { TestId as SessionConfigTestId } from "components/sessions/session-config/SessionConfig";
+
 import CreateSession from "./CreateSession";
 
 describe("CreateSession", () => {
   let getByRole: any;
+  let getByTestId: any;
 
   beforeEach(() => {
-    ({ getByRole } = render(
+    ({ getByRole, getByTestId } = render(
       <MuiPickersUtilsProvider utils={MomentUtils}>
         <CreateSession />
       </MuiPickersUtilsProvider>
@@ -21,6 +24,12 @@ describe("CreateSession", () => {
     it("renders the step title", () => {
       expect(
         getByRole("heading", { name: "Create a new session" })
+      ).toBeInTheDocument();
+    });
+
+    it("renders the step content", () => {
+      expect(
+        getByTestId(SessionConfigTestId.SessionConfig)
       ).toBeInTheDocument();
     });
 


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

["Create a session" step](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=9beac3fc1b4045d3997f096ea99d6fcd)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- added a `SessionConfig` component that includes inputs for the session name & start date
- changed the DatePicker to a KeyboardDatePicker to allow for testing
  - i simply could not find docs on how to properly test the DatePicker
  - the main change is it allows users to type in dates in a "MM/DD/YYYY" format (doesn't seem to support any fancier format strings), which could be handy? maybe?
- added tests

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. open localhost:3000/sessions/create and play with the inputs

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- readability 📚 
- any concerns with using the KeyboardDateInput instead?

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
