### PR TITLE
Display the enrolled class & status of families in the selected session

### DIFF
--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -65,7 +65,7 @@ export type FamilyListResponse = Pick<
   | DefaultFieldKey.PREFERRED_CONTACT
   | "parent"
 > & {
-  current_enrolment: Enrolment | null;
+  enrolment: Enrolment | null;
 };
 
 export type FamilySearchResponse = Pick<

--- a/src/components/families/family-list/family-table/FamilyTable.tsx
+++ b/src/components/families/family-list/family-table/FamilyTable.tsx
@@ -84,7 +84,7 @@ const FamilyTable = ({
   const { parentDynamicFields } = useContext(DynamicFieldsContext);
 
   const getTableRows = (): FamilyTableRow[] =>
-    families.map(({ parent, children, current_enrolment, ...args }) => {
+    families.map(({ parent, children, enrolment, ...args }) => {
       let childrenInfo = "";
       children.forEach((child, i) => {
         if (child.date_of_birth) {
@@ -100,7 +100,7 @@ const FamilyTable = ({
         }
       });
 
-      const enrolment = current_enrolment || {
+      const enrolmentData = enrolment || {
         enrolled_class: null,
         preferred_class: null,
         status: EnrolmentStatus.UNASSIGNED,
@@ -109,13 +109,13 @@ const FamilyTable = ({
         [DefaultFieldKey.FIRST_NAME]: parent.first_name,
         [DefaultFieldKey.LAST_NAME]: parent.last_name,
         [DefaultFieldKey.CHILDREN]: childrenInfo,
-        [DefaultFieldKey.STATUS]: enrolment.status,
-        [DefaultFieldKey.IS_ENROLLED]: current_enrolment ? "True" : "False",
-        [DefaultFieldKey.CURRENT_CLASS]: enrolment.enrolled_class
-          ? enrolment.enrolled_class.name
+        [DefaultFieldKey.STATUS]: enrolmentData.status,
+        [DefaultFieldKey.IS_ENROLLED]: enrolment ? "True" : "False",
+        [DefaultFieldKey.CURRENT_CLASS]: enrolmentData.enrolled_class
+          ? enrolmentData.enrolled_class.name
           : "N/A",
-        [DefaultFieldKey.CURRENT_PREFERRED_CLASS]: enrolment.preferred_class
-          ? enrolment.preferred_class.name
+        [DefaultFieldKey.CURRENT_PREFERRED_CLASS]: enrolmentData.preferred_class
+          ? enrolmentData.preferred_class.name
           : "N/A",
         ...args,
       };


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Display the enrolled class & status of families in the selected session](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=16114024596844d3b60f80dcc1560a9a)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- renames current_enrolment → enrolment in the FamilyListResponse (renamed in [this backend PR](https://github.com/uwblueprint/project-read-backend/pull/90))

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. open the registration table and ensure enrolment fields appear as expected
2. in the sessions page, enrolment columns should be populated for past sessions (not just the current one)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- testing

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
