### PR TITLE
Fix scrolling bug on sidebar close 🐛 

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -20,6 +20,7 @@ const theme = createMuiTheme({
     MuiAppBar: {
       root: {
         boxShadow: "none",
+        zIndex: defaultTheme.zIndex.drawer + 1,
       },
     },
     MuiButton: {


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

on chrome, there's a weird scrolling 🐛 when the family sidebar is closed due to some sticky properties in the mui-datatable component

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- changed the sidebar from temporary to permanent, and added listeners to for us to listen to and handle click events on our own

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. open & close the sidebar
2. verify that there is 🚫 no unwanted scrolling 🚫 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- 🚫 no unwanted scrolling 🚫 

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
