### PR TITLE
Display the family form and edit toggle in the sidebar (3/n)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,6 +27,7 @@
       }
     ],
     "react/jsx-filename-extension": [1, { "extensions": [".jsx", ".tsx"] }],
+    "react/jsx-props-no-spreading": [1, { "exceptions": ["Field"] }],
     "no-use-before-define": "off",
     "import/order": [
       "error",

--- a/src/api/FamilyAPI.ts
+++ b/src/api/FamilyAPI.ts
@@ -2,8 +2,8 @@ import * as APIUtils from "./APIUtils";
 import {
   FamilyListResponse,
   FamilyDetailResponse,
+  FamilyRequest,
   FamilySearchResponse,
-  FamilyStudentRequest,
 } from "./types";
 
 const getFamilies = (): Promise<FamilyListResponse[]> =>
@@ -20,8 +20,7 @@ const getFamiliesByParentName = (
 const getFamilyById = (id: number): Promise<FamilyDetailResponse> =>
   APIUtils.get(`/families/${id}`);
 
-const postFamily = (data: FamilyStudentRequest) =>
-  APIUtils.post("/families/", data);
+const postFamily = (data: FamilyRequest) => APIUtils.post("/families/", data);
 
 export default {
   getFamilies,

--- a/src/api/types/index.tsx
+++ b/src/api/types/index.tsx
@@ -64,7 +64,7 @@ export type FamilySearchResponse = Pick<
   [DefaultFieldKey.LAST_NAME]: string;
 };
 
-export type FamilyRequest = Pick<
+export type FamilyBaseRequest = Pick<
   Family,
   | DefaultFieldKey.ADDRESS
   | DefaultFieldKey.CELL_NUMBER
@@ -83,7 +83,7 @@ export type StudentRequest = Pick<
   | "information"
 >;
 
-export type FamilyStudentRequest = FamilyRequest & {
+export type FamilyRequest = FamilyBaseRequest & {
   children: StudentRequest[];
   guests: StudentRequest[];
   parent: StudentRequest;

--- a/src/components/common/field/Field.tsx
+++ b/src/components/common/field/Field.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 
-import { MenuItem, OutlinedInput, Select } from "@material-ui/core";
+import {
+  Box,
+  MenuItem,
+  OutlinedInput,
+  Select,
+  Typography,
+} from "@material-ui/core";
 import { makeStyles } from "@material-ui/styles";
 import moment from "moment";
 
@@ -19,6 +25,7 @@ const useStyles = makeStyles(() => ({
 
 type Props = {
   field: (DefaultField & { role: StudentRole }) | DynamicField;
+  isEditing: boolean;
   onChange: (value: string) => void;
   variant?: FieldVariant;
   value: string;
@@ -28,9 +35,25 @@ const defaultProps = {
   variant: FieldVariant.DEFAULT,
 };
 
-const Field = ({ field, onChange, value, variant }: Props) => {
+const Field = ({ field, isEditing, onChange, value, variant }: Props) => {
   const classes = useStyles();
   const id = `${field.role} ${field.name}`;
+
+  if (!isEditing) {
+    return (
+      <Box display="flex" paddingY={1}>
+        <Box minWidth={144} paddingRight={2}>
+          <Typography variant="body2">
+            <b>{field.name}</b>
+          </Typography>
+        </Box>
+        <Box>
+          <Typography variant="body2">{value}</Typography>
+        </Box>
+      </Box>
+    );
+  }
+
   return (
     <FormRow
       id={id}

--- a/src/components/families/family-form/family-parent-fields/FamilyParentFields.tsx
+++ b/src/components/families/family-form/family-parent-fields/FamilyParentFields.tsx
@@ -11,12 +11,17 @@ type FamilyParentRequest = FamilyRequest & { parent: StudentRequest };
 type Props = {
   dynamicFields: DynamicField[];
   family: FamilyParentRequest;
+  isEditing: boolean;
   onChange: (data: FamilyParentRequest) => void;
 };
 
-const FamilyParentFields = ({ dynamicFields, family, onChange }: Props) => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const fieldProps = {};
+const FamilyParentFields = ({
+  dynamicFields,
+  family,
+  isEditing,
+  onChange,
+}: Props) => {
+  const fieldProps = { isEditing };
   return (
     <>
       <Field
@@ -28,6 +33,7 @@ const FamilyParentFields = ({ dynamicFields, family, onChange }: Props) => {
           })
         }
         value={family.parent.first_name}
+        {...fieldProps}
       />
       <Field
         field={{ ...DefaultFields.LAST_NAME, role: StudentRole.PARENT }}
@@ -38,6 +44,7 @@ const FamilyParentFields = ({ dynamicFields, family, onChange }: Props) => {
           })
         }
         value={family.parent.last_name}
+        {...fieldProps}
       />
       <Field
         field={{ ...DefaultFields.DATE_OF_BIRTH, role: StudentRole.PARENT }}
@@ -52,41 +59,49 @@ const FamilyParentFields = ({ dynamicFields, family, onChange }: Props) => {
           });
         }}
         value={family.parent.date_of_birth || ""}
+        {...fieldProps}
       />
       <Field
         field={{ ...DefaultFields.HOME_NUMBER, role: StudentRole.PARENT }}
         onChange={(value) => onChange({ ...family, home_number: value })}
         value={family.home_number}
+        {...fieldProps}
       />
       <Field
         field={{ ...DefaultFields.CELL_NUMBER, role: StudentRole.PARENT }}
         onChange={(value) => onChange({ ...family, cell_number: value })}
         value={family.cell_number}
+        {...fieldProps}
       />
       <Field
         field={{ ...DefaultFields.WORK_NUMBER, role: StudentRole.PARENT }}
         onChange={(value) => onChange({ ...family, work_number: value })}
         value={family.work_number}
+        {...fieldProps}
       />
       <Field
         field={{ ...DefaultFields.PREFERRED_NUMBER, role: StudentRole.PARENT }}
         onChange={(value) => onChange({ ...family, preferred_number: value })}
         value={family.preferred_number}
+        {...fieldProps}
       />
       <Field
         field={{ ...DefaultFields.EMAIL, role: StudentRole.PARENT }}
         onChange={(value) => onChange({ ...family, email: value })}
         value={family.email}
+        {...fieldProps}
       />
       <Field
         field={{ ...DefaultFields.ADDRESS, role: StudentRole.PARENT }}
         onChange={(value) => onChange({ ...family, address: value })}
         value={family.address}
+        {...fieldProps}
       />
       <Field
         field={{ ...DefaultFields.PREFERRED_CONTACT, role: StudentRole.PARENT }}
         onChange={(value) => onChange({ ...family, preferred_comms: value })}
         value={family.preferred_comms}
+        {...fieldProps}
       />
       {dynamicFields.map((field) => (
         <Field
@@ -105,6 +120,7 @@ const FamilyParentFields = ({ dynamicFields, family, onChange }: Props) => {
             })
           }
           value={family.parent.information[field.id] ?? ""}
+          {...fieldProps}
         />
       ))}
     </>

--- a/src/components/families/family-form/family-parent-fields/FamilyParentFields.tsx
+++ b/src/components/families/family-form/family-parent-fields/FamilyParentFields.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 
-import { FamilyRequest, StudentRequest } from "api/types";
+import { FamilyBaseRequest, StudentRequest } from "api/types";
 import Field from "components/common/field";
 import { DefaultFields } from "constants/DefaultFields";
 import StudentRole from "constants/StudentRole";
 import { DynamicField } from "types";
 
-type FamilyParentRequest = FamilyRequest & { parent: StudentRequest };
+type FamilyParentRequest = FamilyBaseRequest & { parent: StudentRequest };
 
 type Props = {
   dynamicFields: DynamicField[];

--- a/src/components/families/family-form/family-parent-fields/FamilyParentFields.tsx
+++ b/src/components/families/family-form/family-parent-fields/FamilyParentFields.tsx
@@ -14,91 +14,101 @@ type Props = {
   onChange: (data: FamilyParentRequest) => void;
 };
 
-const FamilyParentFields = ({ dynamicFields, family, onChange }: Props) => (
-  <>
-    <Field
-      field={{ ...DefaultFields.FIRST_NAME, role: StudentRole.PARENT }}
-      onChange={(value) =>
-        onChange({ ...family, parent: { ...family.parent, first_name: value } })
-      }
-      value={family.parent.first_name}
-    />
-    <Field
-      field={{ ...DefaultFields.LAST_NAME, role: StudentRole.PARENT }}
-      onChange={(value) =>
-        onChange({ ...family, parent: { ...family.parent, last_name: value } })
-      }
-      value={family.parent.last_name}
-    />
-    <Field
-      field={{ ...DefaultFields.DATE_OF_BIRTH, role: StudentRole.PARENT }}
-      onChange={(value) => {
-        const dob = value || null;
-        onChange({
-          ...family,
-          parent: {
-            ...family.parent,
-            date_of_birth: dob,
-          },
-        });
-      }}
-      value={family.parent.date_of_birth || ""}
-    />
-    <Field
-      field={{ ...DefaultFields.HOME_NUMBER, role: StudentRole.PARENT }}
-      onChange={(value) => onChange({ ...family, home_number: value })}
-      value={family.home_number}
-    />
-    <Field
-      field={{ ...DefaultFields.CELL_NUMBER, role: StudentRole.PARENT }}
-      onChange={(value) => onChange({ ...family, cell_number: value })}
-      value={family.cell_number}
-    />
-    <Field
-      field={{ ...DefaultFields.WORK_NUMBER, role: StudentRole.PARENT }}
-      onChange={(value) => onChange({ ...family, work_number: value })}
-      value={family.work_number}
-    />
-    <Field
-      field={{ ...DefaultFields.PREFERRED_NUMBER, role: StudentRole.PARENT }}
-      onChange={(value) => onChange({ ...family, preferred_number: value })}
-      value={family.preferred_number}
-    />
-    <Field
-      field={{ ...DefaultFields.EMAIL, role: StudentRole.PARENT }}
-      onChange={(value) => onChange({ ...family, email: value })}
-      value={family.email}
-    />
-    <Field
-      field={{ ...DefaultFields.ADDRESS, role: StudentRole.PARENT }}
-      onChange={(value) => onChange({ ...family, address: value })}
-      value={family.address}
-    />
-    <Field
-      field={{ ...DefaultFields.PREFERRED_CONTACT, role: StudentRole.PARENT }}
-      onChange={(value) => onChange({ ...family, preferred_comms: value })}
-      value={family.preferred_comms}
-    />
-    {dynamicFields.map((field) => (
+const FamilyParentFields = ({ dynamicFields, family, onChange }: Props) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const fieldProps = {};
+  return (
+    <>
       <Field
-        key={field.id}
-        field={field}
+        field={{ ...DefaultFields.FIRST_NAME, role: StudentRole.PARENT }}
         onChange={(value) =>
+          onChange({
+            ...family,
+            parent: { ...family.parent, first_name: value },
+          })
+        }
+        value={family.parent.first_name}
+      />
+      <Field
+        field={{ ...DefaultFields.LAST_NAME, role: StudentRole.PARENT }}
+        onChange={(value) =>
+          onChange({
+            ...family,
+            parent: { ...family.parent, last_name: value },
+          })
+        }
+        value={family.parent.last_name}
+      />
+      <Field
+        field={{ ...DefaultFields.DATE_OF_BIRTH, role: StudentRole.PARENT }}
+        onChange={(value) => {
+          const dob = value || null;
           onChange({
             ...family,
             parent: {
               ...family.parent,
-              information: {
-                ...family.parent.information,
-                [field.id]: value,
-              },
+              date_of_birth: dob,
             },
-          })
-        }
-        value={family.parent.information[field.id] ?? ""}
+          });
+        }}
+        value={family.parent.date_of_birth || ""}
       />
-    ))}
-  </>
-);
+      <Field
+        field={{ ...DefaultFields.HOME_NUMBER, role: StudentRole.PARENT }}
+        onChange={(value) => onChange({ ...family, home_number: value })}
+        value={family.home_number}
+      />
+      <Field
+        field={{ ...DefaultFields.CELL_NUMBER, role: StudentRole.PARENT }}
+        onChange={(value) => onChange({ ...family, cell_number: value })}
+        value={family.cell_number}
+      />
+      <Field
+        field={{ ...DefaultFields.WORK_NUMBER, role: StudentRole.PARENT }}
+        onChange={(value) => onChange({ ...family, work_number: value })}
+        value={family.work_number}
+      />
+      <Field
+        field={{ ...DefaultFields.PREFERRED_NUMBER, role: StudentRole.PARENT }}
+        onChange={(value) => onChange({ ...family, preferred_number: value })}
+        value={family.preferred_number}
+      />
+      <Field
+        field={{ ...DefaultFields.EMAIL, role: StudentRole.PARENT }}
+        onChange={(value) => onChange({ ...family, email: value })}
+        value={family.email}
+      />
+      <Field
+        field={{ ...DefaultFields.ADDRESS, role: StudentRole.PARENT }}
+        onChange={(value) => onChange({ ...family, address: value })}
+        value={family.address}
+      />
+      <Field
+        field={{ ...DefaultFields.PREFERRED_CONTACT, role: StudentRole.PARENT }}
+        onChange={(value) => onChange({ ...family, preferred_comms: value })}
+        value={family.preferred_comms}
+      />
+      {dynamicFields.map((field) => (
+        <Field
+          key={field.id}
+          field={field}
+          onChange={(value) =>
+            onChange({
+              ...family,
+              parent: {
+                ...family.parent,
+                information: {
+                  ...family.parent.information,
+                  [field.id]: value,
+                },
+              },
+            })
+          }
+          value={family.parent.information[field.id] ?? ""}
+        />
+      ))}
+    </>
+  );
+};
 
 export default FamilyParentFields;

--- a/src/components/families/family-form/student-form/StudentForm.tsx
+++ b/src/components/families/family-form/student-form/StudentForm.tsx
@@ -69,13 +69,21 @@ const defaultStudentData: StudentRequest = {
 
 type Props = {
   dynamicFields: DynamicField[];
+  isEditing: boolean;
   onChange: (students: StudentFormData[]) => void;
   role: StudentRole.CHILD | StudentRole.GUEST;
   students: StudentFormData[];
 };
 
-const StudentForm = ({ dynamicFields, onChange, role, students }: Props) => {
+const StudentForm = ({
+  dynamicFields,
+  isEditing,
+  onChange,
+  role,
+  students,
+}: Props) => {
   const classes = useStyles();
+  const fieldProps = { isEditing, variant: FieldVariant.COMPACT };
 
   const onAddStudent = (): void => {
     onChange([
@@ -105,15 +113,16 @@ const StudentForm = ({ dynamicFields, onChange, role, students }: Props) => {
         {students.map((student, i) => (
           <Box key={student.index} display="flex">
             <Box className={classes.rowContainer} width={32}>
-              {(role === StudentRole.GUEST || students.length > 1) && (
-                <IconButton
-                  aria-label={`delete ${role}`}
-                  onClick={() => onDeleteStudent(student.index)}
-                  className={classes.deleteButton}
-                >
-                  <RemoveCircle className={classes.deleteButtonIcon} />
-                </IconButton>
-              )}
+              {isEditing &&
+                (role === StudentRole.GUEST || students.length > 1) && (
+                  <IconButton
+                    aria-label={`delete ${role}`}
+                    onClick={() => onDeleteStudent(student.index)}
+                    className={classes.deleteButton}
+                  >
+                    <RemoveCircle className={classes.deleteButtonIcon} />
+                  </IconButton>
+                )}
             </Box>
             <div>
               <Field
@@ -122,7 +131,7 @@ const StudentForm = ({ dynamicFields, onChange, role, students }: Props) => {
                   onUpdateStudent(i, { ...student, first_name: value })
                 }
                 value={student.first_name}
-                variant={FieldVariant.COMPACT}
+                {...fieldProps}
               />
               <Field
                 field={{ ...DefaultFields.LAST_NAME, role }}
@@ -130,7 +139,7 @@ const StudentForm = ({ dynamicFields, onChange, role, students }: Props) => {
                   onUpdateStudent(i, { ...student, last_name: value })
                 }
                 value={student.last_name}
-                variant={FieldVariant.COMPACT}
+                {...fieldProps}
               />
               <Field
                 field={{ ...DefaultFields.DATE_OF_BIRTH, role }}
@@ -142,7 +151,7 @@ const StudentForm = ({ dynamicFields, onChange, role, students }: Props) => {
                   });
                 }}
                 value={student.date_of_birth || ""}
-                variant={FieldVariant.COMPACT}
+                {...fieldProps}
               />
               {dynamicFields.map((field) => (
                 <Field
@@ -158,20 +167,22 @@ const StudentForm = ({ dynamicFields, onChange, role, students }: Props) => {
                     })
                   }
                   value={student.information[field.id] ?? ""}
-                  variant={FieldVariant.COMPACT}
+                  {...fieldProps}
                 />
               ))}
             </div>
           </Box>
         ))}
-        <Button
-          onClick={onAddStudent}
-          className={classes.addButton}
-          variant="outlined"
-        >
-          <Add fontSize="small" className={classes.addButtonIcon} />
-          Add {role === StudentRole.CHILD ? "child" : "member"}
-        </Button>
+        {isEditing && (
+          <Button
+            onClick={onAddStudent}
+            className={classes.addButton}
+            variant="outlined"
+          >
+            <Add fontSize="small" className={classes.addButtonIcon} />
+            Add {role === StudentRole.CHILD ? "child" : "member"}
+          </Button>
+        )}
       </div>
     </Box>
   );

--- a/src/components/families/family-form/utils.ts
+++ b/src/components/families/family-form/utils.ts
@@ -26,9 +26,17 @@ export const familyResponseToFamilyFormData = (
   ),
 });
 
-export const studentFormDataToStudentRequest = (
+const studentFormDataToStudentRequest = (
   obj: StudentFormData
 ): StudentRequest => {
   const { index, ...req } = obj;
   return req as StudentRequest;
 };
+
+export const familyFormDataToFamilyRequest = (family: FamilyFormData) => ({
+  ...family,
+  children: family.children.map((child) =>
+    studentFormDataToStudentRequest(child)
+  ),
+  guests: family.guests.map((guest) => studentFormDataToStudentRequest(guest)),
+});

--- a/src/components/families/family-form/utils.ts
+++ b/src/components/families/family-form/utils.ts
@@ -1,9 +1,13 @@
-import { FamilyDetailResponse, FamilyRequest, StudentRequest } from "api/types";
+import {
+  FamilyDetailResponse,
+  FamilyBaseRequest,
+  StudentRequest,
+} from "api/types";
 import StudentRole from "constants/StudentRole";
 
 import { generateKey, StudentFormData } from "./student-form";
 
-export type FamilyFormData = FamilyRequest & {
+export type FamilyFormData = FamilyBaseRequest & {
   children: StudentFormData[];
   guests: StudentFormData[];
   parent: StudentRequest;

--- a/src/components/families/family-form/utils.ts
+++ b/src/components/families/family-form/utils.ts
@@ -1,6 +1,7 @@
 import {
-  FamilyDetailResponse,
   FamilyBaseRequest,
+  FamilyDetailResponse,
+  FamilyRequest,
   StudentRequest,
 } from "api/types";
 import StudentRole from "constants/StudentRole";
@@ -37,7 +38,9 @@ const studentFormDataToStudentRequest = (
   return req as StudentRequest;
 };
 
-export const familyFormDataToFamilyRequest = (family: FamilyFormData) => ({
+export const familyFormDataToFamilyRequest = (
+  family: FamilyFormData
+): FamilyRequest => ({
   ...family,
   children: family.children.map((child) =>
     studentFormDataToStudentRequest(child)

--- a/src/components/families/family-list/FamilyList.tsx
+++ b/src/components/families/family-list/FamilyList.tsx
@@ -1,9 +1,13 @@
 import React, { useState } from "react";
 
 import FamilyAPI from "api/FamilyAPI";
-import { FamilyDetailResponse, FamilyListResponse } from "api/types";
+import { FamilyListResponse } from "api/types";
 import { DefaultField } from "types";
 
+import {
+  familyResponseToFamilyFormData,
+  FamilyFormData,
+} from "../family-form/utils";
 import FamilySidebar from "./family-sidebar";
 import FamilyTable from "./family-table";
 
@@ -18,14 +22,12 @@ const FamilyList = ({
   enrolmentFields,
   shouldDisplayDynamicFields,
 }: Props) => {
-  const [
-    selectedFamily,
-    setSelectedFamily,
-  ] = useState<FamilyDetailResponse | null>(null);
+  const [selectedFamily, setSelectedFamily] = useState<FamilyFormData>();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
   const onSelectFamily = async (id: number) => {
-    setSelectedFamily(await FamilyAPI.getFamilyById(id));
+    const family = await FamilyAPI.getFamilyById(id);
+    setSelectedFamily(familyResponseToFamilyFormData(family));
     setIsSidebarOpen(true);
   };
 

--- a/src/components/families/family-list/family-sidebar/FamilySidebar.tsx
+++ b/src/components/families/family-list/family-sidebar/FamilySidebar.tsx
@@ -1,12 +1,20 @@
-import React, { useContext, useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
-import { Box, Drawer, Divider, Typography, TextField } from "@material-ui/core";
+import {
+  Box,
+  Drawer,
+  Divider,
+  IconButton,
+  Typography,
+  TextField,
+} from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
+import { Edit } from "@material-ui/icons";
 
-import { FamilyDetailResponse } from "api/types";
+import { FamilyFormData } from "components/families/family-form/utils";
 import DefaultFieldKey from "constants/DefaultFieldKey";
-import { DefaultFamilyFormFields } from "constants/DefaultFields";
-import { DynamicFieldsContext } from "context/DynamicFieldsContext";
+
+import FamilySidebarForm from "./family-sidebar-form";
 
 const drawerWidth = 416;
 
@@ -31,15 +39,17 @@ const useStyles = makeStyles(() => ({
 }));
 
 type Props = {
+  family: FamilyFormData;
   isOpen: boolean;
-  family: FamilyDetailResponse;
   onClose: () => void;
 };
 
-const FamilySidebar = ({ isOpen, family, onClose }: Props) => {
+const FamilySidebar = ({ family, isOpen, onClose }: Props) => {
   const classes = useStyles();
-  const { parentDynamicFields } = useContext(DynamicFieldsContext);
   const sidebar = useRef<HTMLDivElement>(null);
+
+  const [familyFormData, setFamilyFormData] = useState<FamilyFormData>(family);
+  const [isEditing, setIsEditing] = useState(false);
 
   const handleClick = (e: MouseEvent) => {
     const sidebarRef = sidebar?.current;
@@ -64,6 +74,27 @@ const FamilySidebar = ({ isOpen, family, onClose }: Props) => {
     return () => {};
   }, [isOpen]);
 
+  useEffect(() => {
+    setFamilyFormData(family);
+  }, [family]);
+
+  const onToggleEdit = (editing: boolean) => {
+    if (isEditing) {
+      setFamilyFormData(family);
+    }
+    setIsEditing(editing);
+  };
+
+  const handleClose = () => {
+    onToggleEdit(false);
+    onClose();
+  };
+
+  const onSubmitFamilyForm = () => {
+    // TODO: make PUT request
+    setIsEditing(false);
+  };
+
   return (
     <Drawer
       anchor="right"
@@ -76,7 +107,7 @@ const FamilySidebar = ({ isOpen, family, onClose }: Props) => {
         paper: classes.drawerPaper,
       }}
       open={isOpen}
-      onClose={onClose}
+      onClose={handleClose}
       PaperProps={{ ref: sidebar }}
     >
       <Box padding={3} paddingTop={10}>
@@ -84,28 +115,22 @@ const FamilySidebar = ({ isOpen, family, onClose }: Props) => {
           {family.parent.first_name} {family.parent.last_name}
         </Typography>
         <Divider variant="fullWidth" />
-        <Typography variant="h3" className={classes.heading}>
-          Basic Information
-        </Typography>
-        {DefaultFamilyFormFields.map((defaultField) => (
-          <Typography
-            variant="body2"
-            className={classes.pb}
-            key={defaultField.name}
-          >
-            <b>{defaultField.name}:</b> {(family as any)[defaultField.id]}
-          </Typography>
-        ))}
-        {parentDynamicFields.map((parentField) => (
-          <Typography
-            variant="body2"
-            className={classes.pb}
-            key={parentField.id}
-          >
-            <b>{parentField.name}:</b>{" "}
-            {family.parent.information[parentField.id]}
-          </Typography>
-        ))}
+        <Box position="relative">
+          <Box position="absolute" top={0} right={0}>
+            <IconButton onClick={() => onToggleEdit(!isEditing)}>
+              <Edit />
+            </IconButton>
+          </Box>
+          <Box>
+            <FamilySidebarForm
+              family={familyFormData}
+              isEditing={isEditing}
+              onCancel={() => onToggleEdit(false)}
+              onChange={setFamilyFormData}
+              onSubmit={onSubmitFamilyForm}
+            />
+          </Box>
+        </Box>
         <Typography variant="h3" className={classes.heading}>
           Notes
         </Typography>

--- a/src/components/families/family-list/family-sidebar/family-sidebar-form/FamilySidebarForm.tsx
+++ b/src/components/families/family-list/family-sidebar/family-sidebar-form/FamilySidebarForm.tsx
@@ -1,0 +1,81 @@
+import React, { useContext } from "react";
+
+import { Button, Typography } from "@material-ui/core";
+
+import { FamilyStudentRequest } from "api/types";
+import FamilyParentFields from "components/families/family-form/family-parent-fields";
+import StudentForm from "components/families/family-form/student-form";
+import {
+  FamilyFormData,
+  familyFormDataToFamilyRequest,
+} from "components/families/family-form/utils";
+import StudentRole from "constants/StudentRole";
+import { DynamicFieldsContext } from "context/DynamicFieldsContext";
+
+type Props = {
+  family: FamilyFormData;
+  isEditing: boolean;
+  onCancel: () => void;
+  onChange: (family: FamilyFormData) => void;
+  onSubmit: (family: FamilyStudentRequest) => void;
+};
+
+const FamilySidebarForm = ({
+  family,
+  isEditing,
+  onCancel,
+  onChange,
+  onSubmit,
+}: Props) => {
+  const {
+    childDynamicFields,
+    guestDynamicFields,
+    parentDynamicFields,
+  } = useContext(DynamicFieldsContext);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    onSubmit(familyFormDataToFamilyRequest(family));
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Typography variant="h3">Basic information</Typography>
+      <FamilyParentFields
+        dynamicFields={parentDynamicFields}
+        isEditing={isEditing}
+        family={family}
+        onChange={(value) => onChange({ ...family, ...value })}
+      />
+      {/* TODO: add session questions here */}
+
+      <Typography variant="h3">Family members</Typography>
+      <StudentForm
+        dynamicFields={childDynamicFields}
+        isEditing={isEditing}
+        onChange={(children) => onChange({ ...family, children })}
+        role={StudentRole.CHILD}
+        students={family.children}
+      />
+      <StudentForm
+        dynamicFields={guestDynamicFields}
+        isEditing={isEditing}
+        onChange={(guests) => onChange({ ...family, guests })}
+        role={StudentRole.GUEST}
+        students={family.guests}
+      />
+      {isEditing && (
+        <>
+          <Button type="button" variant="outlined" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button type="submit" variant="contained" color="primary">
+            Save
+          </Button>
+        </>
+      )}
+    </form>
+  );
+};
+
+export default FamilySidebarForm;

--- a/src/components/families/family-list/family-sidebar/family-sidebar-form/FamilySidebarForm.tsx
+++ b/src/components/families/family-list/family-sidebar/family-sidebar-form/FamilySidebarForm.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react";
 
 import { Button, Typography } from "@material-ui/core";
 
-import { FamilyStudentRequest } from "api/types";
+import { FamilyRequest } from "api/types";
 import FamilyParentFields from "components/families/family-form/family-parent-fields";
 import StudentForm from "components/families/family-form/student-form";
 import {
@@ -17,7 +17,7 @@ type Props = {
   isEditing: boolean;
   onCancel: () => void;
   onChange: (family: FamilyFormData) => void;
-  onSubmit: (family: FamilyStudentRequest) => void;
+  onSubmit: (family: FamilyRequest) => void;
 };
 
 const FamilySidebarForm = ({

--- a/src/components/families/family-list/family-sidebar/family-sidebar-form/index.ts
+++ b/src/components/families/family-list/family-sidebar/family-sidebar-form/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./FamilySidebarForm";

--- a/src/components/registration/registration-form/RegistrationForm.tsx
+++ b/src/components/registration/registration-form/RegistrationForm.tsx
@@ -5,7 +5,6 @@ import { makeStyles } from "@material-ui/styles";
 
 import FamilyAPI from "api/FamilyAPI";
 import {
-  FamilyStudentRequest,
   StudentRequest,
   SessionDetailResponse,
   FamilyDetailResponse,
@@ -14,8 +13,8 @@ import FamilyParentFields from "components/families/family-form/family-parent-fi
 import StudentForm from "components/families/family-form/student-form";
 import {
   FamilyFormData,
+  familyFormDataToFamilyRequest,
   familyResponseToFamilyFormData,
-  studentFormDataToStudentRequest,
 } from "components/families/family-form/utils";
 import DefaultFieldKey from "constants/DefaultFieldKey";
 import StudentRole from "constants/StudentRole";
@@ -85,17 +84,10 @@ const RegistrationForm = ({
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const requestData: FamilyStudentRequest = {
-      ...family,
-      children: family.children.map((child) =>
-        studentFormDataToStudentRequest(child)
-      ),
-      guests: family.guests.map((guest) =>
-        studentFormDataToStudentRequest(guest)
-      ),
-    };
     if (existingFamily === null) {
-      const response = await FamilyAPI.postFamily(requestData);
+      const response = await FamilyAPI.postFamily(
+        familyFormDataToFamilyRequest(family)
+      );
       if (response.non_field_errors) {
         // eslint-disable-next-line no-alert
         alert(response.non_field_errors);
@@ -137,6 +129,7 @@ const RegistrationForm = ({
         <Typography variant="h3">Basic information</Typography>
         <FamilyParentFields
           dynamicFields={getSessionDynamicFields(parentDynamicFields)}
+          isEditing
           family={family}
           onChange={(value) => setFamily({ ...family, ...value })}
         />
@@ -144,12 +137,14 @@ const RegistrationForm = ({
         <Typography variant="h3">Family members</Typography>
         <StudentForm
           dynamicFields={getSessionDynamicFields(childDynamicFields)}
+          isEditing
           onChange={(children) => setFamily({ ...family, children })}
           role={StudentRole.CHILD}
           students={family.children}
         />
         <StudentForm
           dynamicFields={getSessionDynamicFields(guestDynamicFields)}
+          isEditing
           onChange={(guests) => setFamily({ ...family, guests })}
           role={StudentRole.GUEST}
           students={family.guests}


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Display a form when editing the family, children, and guests](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=339f42db2c08477ea9a29fb6e419b198)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

looks a little wonky but will be styled in an upcoming PR

- adds a `FamilySidebarForm` component that's now rendered in the family sidebar
- adds `isEditing` props to `Field`, `FamilyParentFields` and `StudentForm` to determine whether to display read-only or editable versions of the form
- adds an edit button the to the sidebar to determine which version of the form to display

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. open the sidebar, and play with the toggle!

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- code quality

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
