### PR TITLE
Add preferred class and status questions to registration

### DIFF
--- a/src/api/EnrolmentAPI.ts
+++ b/src/api/EnrolmentAPI.ts
@@ -1,7 +1,7 @@
 import * as APIUtils from "./APIUtils";
-import { FamilyEnrolmentRequest } from "./types";
+import { EnrolmentFamilyRequest } from "./types";
 
-const postEnrolment = (data: FamilyEnrolmentRequest) =>
+const postEnrolment = (data: EnrolmentFamilyRequest) =>
   APIUtils.post("/enrolments/", data);
 
 export default {

--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -1,8 +1,8 @@
 import DefaultFieldKey from "constants/DefaultFieldKey";
-import EnrolmentStatus from "constants/EnrolmentStatus";
 import {
   Class,
   DynamicField,
+  Enrolment,
   Family,
   Interaction,
   Session,
@@ -25,12 +25,10 @@ export type SessionDetailResponse = Session & {
   families: FamilyListResponse[];
 };
 
-export type Enrolment = {
-  id: number;
+export type EnrolmentResponse = Pick<Enrolment, "id" | "status"> & {
   session: SessionListResponse | null;
   preferred_class: ClassListResponse | null;
   enrolled_class: ClassListResponse | null;
-  status: EnrolmentStatus;
 };
 
 export type InteractionResponse = Interaction & {
@@ -50,9 +48,9 @@ export type FamilyDetailResponse = Pick<
   | "parent"
 > & {
   children: Student[];
-  current_enrolment: Enrolment | null;
-  interactions: InteractionResponse[];
+  current_enrolment: EnrolmentResponse | null;
   guests: Student[];
+  interactions: InteractionResponse[];
 };
 
 export type FamilyListResponse = Pick<
@@ -65,7 +63,7 @@ export type FamilyListResponse = Pick<
   | DefaultFieldKey.PREFERRED_CONTACT
   | "parent"
 > & {
-  enrolment: Enrolment | null;
+  enrolment: EnrolmentResponse | null;
 };
 
 export type FamilySearchResponse = Pick<
@@ -104,11 +102,10 @@ export type FamilyRequest = FamilyBaseRequest & {
   parent: StudentRequest;
 };
 
-export type FamilyEnrolmentRequest = {
+export type EnrolmentFamilyRequest = Pick<Enrolment, "status"> & {
   family: FamilyRequest;
   session: number;
   preferred_class: number | null;
-  status: EnrolmentStatus;
 };
 
 export type DynamicFieldsResponse = {

--- a/src/components/common/form-row/FormRow.tsx
+++ b/src/components/common/form-row/FormRow.tsx
@@ -6,10 +6,43 @@ import { makeStyles } from "@material-ui/styles";
 import FieldVariant from "constants/FieldVariant";
 import QuestionType from "constants/QuestionType";
 
-const useStyles = makeStyles<Theme, Pick<Props, "dense">>(() => ({
+const denseStyles = {
+  formRow: {
+    marginBottom: 4,
+  },
+  labelContainer: {
+    minWidth: 128,
+  },
+};
+
+const stackedStyles = {
+  formRow: {
+    alignItems: "",
+    "flex-direction": "column",
+  },
+  labelContainer: {
+    paddingBottom: 12,
+  },
+};
+
+const useStyles = makeStyles<Theme, Pick<Props, "dense" | "variant">>(() => ({
+  formRow: ({ dense, variant }) => ({
+    alignItems: "center",
+    display: "flex",
+    flexDirection: "row",
+    marginBottom: 16,
+    ...(dense && denseStyles.formRow),
+    ...(variant === FieldVariant.STACKED && stackedStyles.formRow),
+  }),
   label: {
     fontSize: ({ dense }) => (dense ? 14 : 16),
   },
+  labelContainer: ({ dense, variant }) => ({
+    minWidth: 144,
+    paddingRight: 2,
+    ...(dense && denseStyles.labelContainer),
+    ...(variant === FieldVariant.STACKED && stackedStyles.labelContainer),
+  }),
 }));
 
 type Props = {
@@ -34,27 +67,21 @@ const FormRow = ({
   questionType,
   variant,
 }: Props) => {
-  const classes = useStyles({ dense });
+  const classes = useStyles({ dense, variant });
 
   const inputLabelProps =
     questionType === QuestionType.MULTIPLE_CHOICE ? { id } : { htmlFor: id };
 
   return (
-    <Box
-      display="flex"
-      flexDirection="row"
-      alignItems="center"
-      marginBottom={dense ? "4px" : 2}
-    >
+    <div className={classes.formRow}>
       {/* hidden input to disable autocomplete: https://gist.github.com/niksumeiko/360164708c3b326bd1c8#gistcomment-3716208 */}
       {questionType === QuestionType.TEXT && (
         <Box display="none" aria-hidden="true">
           <input aria-hidden="true" tabIndex={-1} />
         </Box>
       )}
-      <Box
-        paddingRight={2}
-        minWidth={dense ? 128 : 144}
+      <div
+        className={classes.labelContainer}
         hidden={variant === FieldVariant.COMPACT}
       >
         {
@@ -63,9 +90,9 @@ const FormRow = ({
             {label}
           </InputLabel>
         }
-      </Box>
+      </div>
       <Box flexGrow={1}>{children}</Box>
-    </Box>
+    </div>
   );
 };
 

--- a/src/components/families/family-form/utils.ts
+++ b/src/components/families/family-form/utils.ts
@@ -1,4 +1,5 @@
 import {
+  EnrolmentFamilyRequest,
   FamilyBaseRequest,
   FamilyDetailResponse,
   FamilyRequest,
@@ -12,6 +13,13 @@ export type FamilyFormData = FamilyBaseRequest & {
   children: StudentFormData[];
   guests: StudentFormData[];
   parent: StudentRequest;
+};
+
+export type EnrolmentFormData = Pick<
+  EnrolmentFamilyRequest,
+  "preferred_class" | "session" | "status"
+> & {
+  family: FamilyFormData;
 };
 
 const studentRequestToStudentFormData = (

--- a/src/components/registration/registration-form/RegistrationForm.unit.test.tsx
+++ b/src/components/registration/registration-form/RegistrationForm.unit.test.tsx
@@ -159,7 +159,10 @@ describe("when text fields are submitted", () => {
 
   it("structures the data in the required format", async () => {
     const session: SessionDetailResponse = {
-      classes: [],
+      classes: [
+        { id: 1, name: "Class 1" },
+        { id: 2, name: "Class 2" },
+      ],
       families: [],
       fields: [
         TEST_PARENT_DYNAMIC_FIELD.id,
@@ -304,6 +307,14 @@ describe("when text fields are submitted", () => {
       }
     );
 
+    fireEvent.change(getByTestId(TestId.PreferredClassSelect), {
+      target: { value: session.classes[1].id },
+    });
+
+    fireEvent.change(getByTestId(TestId.StatusSelect), {
+      target: { value: EnrolmentStatus.SIGNED_UP },
+    });
+
     fireEvent.click(getByRole("button", { name: "Done" }));
 
     await waitFor(() =>
@@ -353,9 +364,9 @@ describe("when text fields are submitted", () => {
         preferred_number: "",
         work_number: TEST_PARENT_WORK_NUMBER,
       },
-      preferred_class: null,
+      preferred_class: session.classes[1].id,
       session: session.id,
-      status: EnrolmentStatus.REGISTERED,
+      status: EnrolmentStatus.SIGNED_UP,
     });
 
     expect(onSubmit).toHaveBeenCalledTimes(1);

--- a/src/constants/FieldVariant.ts
+++ b/src/constants/FieldVariant.ts
@@ -1,6 +1,7 @@
 enum FieldVariant {
   COMPACT = "compact",
   DEFAULT = "default",
+  STACKED = "stacked",
 }
 
 export default FieldVariant;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 import DefaultFieldKey from "constants/DefaultFieldKey";
+import EnrolmentStatus from "constants/EnrolmentStatus";
 import StudentRole from "constants/StudentRole";
 
 export type User = {
@@ -70,4 +71,9 @@ export type Class = {
   id: number;
   name: string;
   attendance: Attendance[];
+};
+
+export type Enrolment = {
+  id: number;
+  status: EnrolmentStatus;
 };


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Status question](https://www.notion.so/uwblueprintexecs/Status-question-92906618bd6d47fcb04b50f247fca9b4)
[Preferred class question](https://www.notion.so/uwblueprintexecs/Preferred-class-question-8c4f78093ab941e49e3263c56a122bb2)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- added a new field variant "stacked" that displays the label on top of the input
- refactored the registration form state to include enrolment data
- added the preferred class and status questions
- updated tests to ensure values get sent to the post /enrolments api

<img width="1204" alt="Screen Shot 2021-07-25 at 5 18 13 PM" src="https://user-images.githubusercontent.com/37346399/126913796-a10aa40f-9b63-4e16-8111-38cdc9653b24.png">

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. yarn test

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- testing!

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
