### PR TITLE
Change session season/year to name

### DIFF
--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -18,7 +18,7 @@ export type ClassDetailResponse = Class & {
   families: FamilyListResponse[];
 };
 
-export type SessionListResponse = Pick<Session, "id" | "season" | "year">;
+export type SessionListResponse = Pick<Session, "id" | "name">;
 
 export type SessionDetailResponse = Session & {
   classes: ClassListResponse[];

--- a/src/components/registration/registration-form/RegistrationForm.tsx
+++ b/src/components/registration/registration-form/RegistrationForm.tsx
@@ -135,10 +135,7 @@ const RegistrationForm = ({
             a <b>new family</b>
           </span>
         )}{" "}
-        for{" "}
-        <b>
-          {session.season} {session.year}
-        </b>
+        for <b>{session.name}</b>
       </Typography>
 
       <Box width={488}>

--- a/src/components/registration/registration-form/RegistrationForm.unit.test.tsx
+++ b/src/components/registration/registration-form/RegistrationForm.unit.test.tsx
@@ -25,9 +25,8 @@ describe("when the registration form is opened", () => {
     families: [],
     fields: [],
     id: 1,
-    season: "Fall",
+    name: "Fall 2021",
     start_date: "2021-09-01",
-    year: 2021,
   };
 
   beforeEach(() => {
@@ -124,9 +123,8 @@ describe("when text fields are submitted", () => {
         // guest field not included
       ],
       id: 1,
-      season: "Fall",
+      name: "Fall 2021",
       start_date: "2021-09-01",
-      year: 2021,
     };
     const { getByTestId, queryByTestId } = render(
       <MuiPickersUtilsProvider utils={MomentUtils}>
@@ -170,9 +168,8 @@ describe("when text fields are submitted", () => {
         TEST_GUEST_DYNAMIC_FIELD.id,
       ],
       id: 1,
-      season: "Fall",
+      name: "Fall 2021",
       start_date: "2021-09-01",
-      year: 2021,
     };
 
     jest.spyOn(EnrolmentAPI, "postEnrolment").mockResolvedValue({});

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -157,7 +157,7 @@ const Sessions = () => {
                 >
                   {sessions.map((session) => (
                     <MenuItem key={session.id} value={session.id}>
-                      {session.season} {session.year}
+                      {session.name}
                     </MenuItem>
                   ))}
                   <MenuItem value={NEW_SESSION}>Add new session</MenuItem>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -52,9 +52,8 @@ export type Family = {
 export type Session = {
   fields: number[]; // array of field IDs
   id: number;
-  season: string;
+  name: string;
   start_date: string;
-  year: number;
 };
 
 export type Attendance = {


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Session season/year → name](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=5d5f4a2d77b240239ed31bba13048ded)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- updated frontend types to match the new name column added in [#91 on the backend](https://github.com/uwblueprint/project-read-backend/pull/91)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. yarn test

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- did i miss any season/year references?

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
