### PR TITLE
Display family interactions in the sidebar

### DIFF
--- a/src/api/types/index.tsx
+++ b/src/api/types/index.tsx
@@ -1,6 +1,16 @@
 import DefaultFieldKey from "constants/DefaultFieldKey";
 import EnrolmentStatus from "constants/EnrolmentStatus";
-import { Class, Session, Family, Student, DynamicField } from "types";
+import {
+  Class,
+  DynamicField,
+  Family,
+  Interaction,
+  Session,
+  Student,
+  User,
+} from "types";
+
+export type UserResponse = Pick<User, "id" | "first_name" | "last_name">;
 
 export type ClassListResponse = Pick<Class, "id" | "name">;
 
@@ -23,6 +33,10 @@ export type Enrolment = {
   status: EnrolmentStatus;
 };
 
+export type InteractionResponse = Interaction & {
+  user: UserResponse;
+};
+
 export type FamilyDetailResponse = Pick<
   Family,
   | DefaultFieldKey.ADDRESS
@@ -36,8 +50,9 @@ export type FamilyDetailResponse = Pick<
   | "parent"
 > & {
   children: Student[];
-  guests: Student[];
   current_enrolment: Enrolment | null;
+  interactions: InteractionResponse[];
+  guests: Student[];
 };
 
 export type FamilyListResponse = Pick<

--- a/src/components/families/family-list/FamilyList.tsx
+++ b/src/components/families/family-list/FamilyList.tsx
@@ -1,13 +1,9 @@
 import React, { useState } from "react";
 
 import FamilyAPI from "api/FamilyAPI";
-import { FamilyListResponse } from "api/types";
+import { FamilyDetailResponse, FamilyListResponse } from "api/types";
 import { DefaultField } from "types";
 
-import {
-  familyResponseToFamilyFormData,
-  FamilyFormData,
-} from "../family-form/utils";
 import FamilySidebar from "./family-sidebar";
 import FamilyTable from "./family-table";
 
@@ -22,12 +18,12 @@ const FamilyList = ({
   enrolmentFields,
   shouldDisplayDynamicFields,
 }: Props) => {
-  const [selectedFamily, setSelectedFamily] = useState<FamilyFormData>();
+  const [selectedFamily, setSelectedFamily] = useState<FamilyDetailResponse>();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
   const onSelectFamily = async (id: number) => {
     const family = await FamilyAPI.getFamilyById(id);
-    setSelectedFamily(familyResponseToFamilyFormData(family));
+    setSelectedFamily(family);
     setIsSidebarOpen(true);
   };
 

--- a/src/components/families/family-list/family-sidebar/FamilySidebar.tsx
+++ b/src/components/families/family-list/family-sidebar/FamilySidebar.tsx
@@ -10,42 +10,48 @@ import {
   Button,
 } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
-import { Edit } from "@material-ui/icons";
+import { Add, Edit } from "@material-ui/icons";
+import moment from "moment";
 
-import { FamilyFormData } from "components/families/family-form/utils";
+import { FamilyDetailResponse } from "api/types";
+import {
+  FamilyFormData,
+  familyResponseToFamilyFormData,
+} from "components/families/family-form/utils";
 import DefaultFieldKey from "constants/DefaultFieldKey";
 
+import FamilySidebarCard from "./family-sidebar-card";
 import FamilySidebarForm, { familySidebarFormId } from "./family-sidebar-form";
 
 const drawerWidth = 416;
 
 const useStyles = makeStyles((theme) => ({
+  actionButton: {
+    backgroundColor: theme.palette.backgroundSecondary.default,
+    borderRadius: 8,
+    height: 40,
+    width: 40,
+  },
+  actionButtonIcon: {
+    height: 20,
+    width: 20,
+  },
   drawer: {
     width: drawerWidth,
   },
   drawerPaper: {
-    backgroundColor: "#F5F5F5",
+    backgroundColor: theme.palette.backgroundSecondary.paper,
     borderLeft: "none",
     height: "calc(100% - 64px)",
     marginTop: 64,
     width: drawerWidth,
   },
-  editButton: {
-    borderRadius: 8,
-    height: 40,
-    width: 40,
-  },
-  editButtonIcon: {
-    height: 20,
-    width: 20,
-  },
   formActionRow: {
-    backgroundColor: "#F5F5F5",
+    backgroundColor: theme.palette.backgroundSecondary.paper,
     boxShadow: "rgb(0 0 0 / 12%) 8px 0px 8px 0px",
     zIndex: theme.zIndex.appBar + 1,
   },
   heading: {
-    color: "#42526E",
     fontWeight: 700,
     fontSize: 16,
     paddingBottom: 20,
@@ -58,7 +64,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 type Props = {
-  family: FamilyFormData;
+  family: FamilyDetailResponse;
   isOpen: boolean;
   onClose: () => void;
 };
@@ -67,7 +73,9 @@ const FamilySidebar = ({ family, isOpen, onClose }: Props) => {
   const classes = useStyles();
   const sidebar = useRef<HTMLDivElement>(null);
 
-  const [familyFormData, setFamilyFormData] = useState<FamilyFormData>(family);
+  const [familyFormData, setFamilyFormData] = useState<FamilyFormData>(
+    familyResponseToFamilyFormData(family)
+  );
   const [isEditing, setIsEditing] = useState(false);
 
   const handleClick = (e: MouseEvent) => {
@@ -93,13 +101,17 @@ const FamilySidebar = ({ family, isOpen, onClose }: Props) => {
     return () => {};
   }, [isOpen]);
 
+  const resetFormData = () => {
+    setFamilyFormData(familyResponseToFamilyFormData(family));
+  };
+
   useEffect(() => {
-    setFamilyFormData(family);
+    resetFormData();
   }, [family]);
 
   const onToggleEdit = (editing: boolean) => {
     if (isEditing) {
-      setFamilyFormData(family);
+      resetFormData();
     }
     setIsEditing(editing);
   };
@@ -137,10 +149,10 @@ const FamilySidebar = ({ family, isOpen, onClose }: Props) => {
         <Box position="relative">
           <Box position="absolute" top={8} right={0}>
             <IconButton
-              className={classes.editButton}
+              className={classes.actionButton}
               onClick={() => onToggleEdit(!isEditing)}
             >
-              <Edit className={classes.editButtonIcon} />
+              <Edit className={classes.actionButtonIcon} />
             </IconButton>
           </Box>
           <Box>
@@ -158,6 +170,35 @@ const FamilySidebar = ({ family, isOpen, onClose }: Props) => {
             <Divider />
           </Box>
         )}
+
+        <Box position="relative">
+          <Box position="absolute" top={8} right={0}>
+            <IconButton className={classes.actionButton}>
+              <Add className={classes.actionButtonIcon} />
+            </IconButton>
+          </Box>
+          <Box>
+            <Typography variant="h3" className={classes.heading}>
+              Recent interactions
+            </Typography>
+            {family.interactions.map((interaction) => (
+              <FamilySidebarCard
+                title={
+                  <Typography variant="body2">{interaction.type}</Typography>
+                }
+                content={
+                  <Typography variant="body2">
+                    {interaction.user.first_name}{" "}
+                    {interaction.user.last_name.charAt(0)}. -{" "}
+                    {moment(interaction.date, "YYYY-MM-DD").format(
+                      "MMM. D, YYYY"
+                    )}
+                  </Typography>
+                }
+              />
+            ))}
+          </Box>
+        </Box>
 
         <Typography variant="h3" className={classes.heading}>
           Notes

--- a/src/components/families/family-list/family-sidebar/family-sidebar-card/FamilySidebarCard.tsx
+++ b/src/components/families/family-list/family-sidebar/family-sidebar-card/FamilySidebarCard.tsx
@@ -1,0 +1,45 @@
+import React, { ReactNode } from "react";
+
+import { Box } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme) => ({
+  card: {
+    backgroundColor: theme.palette.backgroundSecondary.default,
+  },
+  content: {
+    "& .MuiTypography-body2": {
+      color: theme.palette.text.secondary,
+      fontSize: 12,
+      fontWeight: 500,
+    },
+  },
+  title: {
+    "& .MuiTypography-body2": {
+      fontWeight: 700,
+    },
+  },
+}));
+
+type Props = {
+  title: ReactNode;
+  content: ReactNode;
+};
+
+const FamilySidebarCard = ({ title, content }: Props) => {
+  const classes = useStyles();
+  return (
+    <Box
+      className={classes.card}
+      borderRadius={4}
+      marginBottom={1.5}
+      paddingX={2}
+      paddingY={1.5}
+    >
+      <div className={classes.title}>{title}</div>
+      <div className={classes.content}>{content}</div>
+    </Box>
+  );
+};
+
+export default FamilySidebarCard;

--- a/src/components/families/family-list/family-sidebar/family-sidebar-card/index.ts
+++ b/src/components/families/family-list/family-sidebar/family-sidebar-card/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./FamilySidebarCard";

--- a/src/shared/theme.d.ts
+++ b/src/shared/theme.d.ts
@@ -1,0 +1,10 @@
+import "@material-ui/core/styles";
+
+declare module "@material-ui/core/styles/createPalette" {
+  interface Palette {
+    backgroundSecondary: Palette["background"];
+  }
+  interface PaletteOptions {
+    backgroundSecondary: PaletteOptions["background"];
+  }
+}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -5,6 +5,10 @@ const defaultTheme = createMuiTheme();
 const theme = createMuiTheme({
   palette: {
     type: "light",
+    backgroundSecondary: {
+      default: "#091e420A",
+      paper: "#F5F5F5",
+    },
   },
   overrides: {
     MuiContainer: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,12 @@
 import DefaultFieldKey from "constants/DefaultFieldKey";
 import StudentRole from "constants/StudentRole";
 
+export type User = {
+  id: number;
+  first_name: string;
+  last_name: string;
+};
+
 type Field = {
   is_default: boolean;
   name: string;
@@ -53,6 +59,11 @@ export type Session = {
 export type Attendance = {
   date: string;
   attendees: number[];
+};
+
+export type Interaction = {
+  date: string;
+  type: string;
 };
 
 export type Class = {


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Tracking recent client interactions](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=3ba42ee5d4df4bf4abcc075bb37f93ba)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- registered interactions in type files (based on [#92 in the backend](https://github.com/uwblueprint/project-read-backend/pull/92))
- created a FamilySidebarCard component that displays each interaction (to be adapted for the past enrolments section)
- added a new `backgroundSecondary` colour set to the theme palette (the light blue-gray that's used in the sidebar)

screenshot (fake data)
<img width="1521" alt="Screen Shot 2021-07-26 at 12 59 06 AM" src="https://user-images.githubusercontent.com/37346399/126935355-3c3a74eb-8a6b-4e90-88b8-e8e465887047.png">

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. run the backend on [#92](https://github.com/uwblueprint/project-read-backend/pull/92)
2. open the sidebar and take a look!

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- correctness, cleanliness

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
