### PR TITLE
Style and set up editing the sidebar notes field

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/react": "^17.0.5",
     "@types/react-dom": "^17.0.3",
     "firebase": "^8.3.0",
+    "lodash": "^4.17.21",
     "moment": "^2.29.1",
     "mui-datatables": "^3.7.6",
     "prop-types": "^15.7.2",
@@ -52,6 +53,7 @@
     ]
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.171",
     "@types/mui-datatables": "^3.7.3",
     "@types/react-router-dom": "^5.1.7",
     "@typescript-eslint/eslint-plugin": "^4.22.1",

--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -42,6 +42,7 @@ export type FamilyDetailResponse = Pick<
   | DefaultFieldKey.EMAIL
   | DefaultFieldKey.HOME_NUMBER
   | DefaultFieldKey.ID
+  | DefaultFieldKey.NOTES
   | DefaultFieldKey.PREFERRED_CONTACT
   | DefaultFieldKey.PREFERRED_NUMBER
   | DefaultFieldKey.WORK_NUMBER
@@ -83,6 +84,7 @@ export type FamilyBaseRequest = Pick<
   | DefaultFieldKey.CELL_NUMBER
   | DefaultFieldKey.EMAIL
   | DefaultFieldKey.HOME_NUMBER
+  | DefaultFieldKey.NOTES
   | DefaultFieldKey.PREFERRED_CONTACT
   | DefaultFieldKey.PREFERRED_NUMBER
   | DefaultFieldKey.WORK_NUMBER

--- a/src/components/registration/registration-form/RegistrationForm.tsx
+++ b/src/components/registration/registration-form/RegistrationForm.tsx
@@ -1,6 +1,13 @@
 import React, { useContext, useState } from "react";
 
-import { Box, Button, MenuItem, Select, Typography } from "@material-ui/core";
+import {
+  Box,
+  Button,
+  MenuItem,
+  OutlinedInput,
+  Select,
+  Typography,
+} from "@material-ui/core";
 import { makeStyles } from "@material-ui/styles";
 
 import EnrolmentAPI from "api/EnrolmentAPI";
@@ -38,6 +45,7 @@ const useStyles = makeStyles(() => ({
 }));
 
 export enum TestId {
+  NotesInput = "notes-input",
   PreferredClassSelect = "preferred-class-select",
   RegistrationForm = "registration-form",
   SessionLabel = "session-label",
@@ -56,6 +64,7 @@ const defaultFamilyData: FamilyFormData = {
   [DefaultFieldKey.CELL_NUMBER]: "",
   [DefaultFieldKey.EMAIL]: "",
   [DefaultFieldKey.HOME_NUMBER]: "",
+  [DefaultFieldKey.NOTES]: "",
   [DefaultFieldKey.PREFERRED_CONTACT]: "",
   [DefaultFieldKey.PREFERRED_NUMBER]: "",
   [DefaultFieldKey.WORK_NUMBER]: "",
@@ -154,7 +163,6 @@ const RegistrationForm = ({
             })
           }
         />
-
         <Typography variant="h3" className={classes.heading}>
           Family members
         </Typography>
@@ -184,7 +192,9 @@ const RegistrationForm = ({
           role={StudentRole.GUEST}
           students={enrolment.family.guests}
         />
+      </Box>
 
+      <Box width={408}>
         <Typography variant="h3" className={classes.heading}>
           Session questions
         </Typography>
@@ -246,6 +256,32 @@ const RegistrationForm = ({
               Signed up (more information is required)
             </MenuItem>
           </Select>
+        </FormRow>
+      </Box>
+
+      <Box width={840}>
+        <Typography variant="h3" className={classes.heading}>
+          Notes
+        </Typography>
+        <FormRow
+          id="notes"
+          label="Notes"
+          questionType={QuestionType.TEXT}
+          variant={FieldVariant.COMPACT}
+        >
+          <OutlinedInput
+            fullWidth
+            id="notes"
+            inputProps={{ "data-testid": TestId.NotesInput }}
+            multiline
+            onChange={(e) =>
+              setEnrolment({
+                ...enrolment,
+                family: { ...enrolment.family, notes: e.target.value },
+              })
+            }
+            value={enrolment.family.notes}
+          />
         </FormRow>
       </Box>
 

--- a/src/components/registration/registration-form/RegistrationForm.unit.test.tsx
+++ b/src/components/registration/registration-form/RegistrationForm.unit.test.tsx
@@ -87,6 +87,8 @@ const TEST_GUEST_FAV_COLOUR = "periwinkle";
 const TEST_GUEST_FIRST_NAME = "Dory";
 const TEST_GUEST_DOB = "01011987";
 
+const TEST_NOTES = "Just keep swimming";
+
 const TEST_DYNAMIC_FIELD = {
   is_default: false,
   name: "Favourite colour",
@@ -312,6 +314,10 @@ describe("when text fields are submitted", () => {
       target: { value: EnrolmentStatus.SIGNED_UP },
     });
 
+    fireEvent.change(getByTestId(TestId.NotesInput), {
+      target: { value: TEST_NOTES },
+    });
+
     fireEvent.click(getByRole("button", { name: "Done" }));
 
     await waitFor(() =>
@@ -347,6 +353,7 @@ describe("when text fields are submitted", () => {
           },
         ],
         home_number: TEST_PARENT_HOME_NUMBER,
+        notes: TEST_NOTES,
         parent: {
           date_of_birth: moment(TEST_PARENT_DOB, "MMDDYYYY").format(
             "YYYY-MM-DD"

--- a/src/pages/MainRegistration.tsx
+++ b/src/pages/MainRegistration.tsx
@@ -3,11 +3,7 @@ import React, { useEffect, useState } from "react";
 import { Typography } from "@material-ui/core";
 
 import FamilyAPI from "api/FamilyAPI";
-import {
-  FamilyDetailResponse,
-  FamilyListResponse,
-  FamilyRequest,
-} from "api/types";
+import { FamilyDetailResponse, FamilyListResponse } from "api/types";
 import FamilySidebar from "components/families/family-sidebar";
 import FamilyTable from "components/families/family-table";
 import { DefaultFields } from "constants/DefaultFields";
@@ -33,13 +29,7 @@ const MainRegistration = () => {
     setIsSidebarOpen(true);
   };
 
-  const onEditFamily = async (data: FamilyRequest) => {
-    if (selectedFamily === null) {
-      return;
-    }
-    console.log(selectedFamily.id);
-    console.log(data);
-  };
+  const onEditFamily = async () => {};
 
   return (
     <>

--- a/src/pages/MainRegistration.tsx
+++ b/src/pages/MainRegistration.tsx
@@ -3,7 +3,11 @@ import React, { useEffect, useState } from "react";
 import { Typography } from "@material-ui/core";
 
 import FamilyAPI from "api/FamilyAPI";
-import { FamilyDetailResponse, FamilyListResponse } from "api/types";
+import {
+  FamilyDetailResponse,
+  FamilyListResponse,
+  FamilyRequest,
+} from "api/types";
 import FamilySidebar from "components/families/family-sidebar";
 import FamilyTable from "components/families/family-table";
 import { DefaultFields } from "constants/DefaultFields";
@@ -29,6 +33,14 @@ const MainRegistration = () => {
     setIsSidebarOpen(true);
   };
 
+  const onEditFamily = async (data: FamilyRequest) => {
+    if (selectedFamily === null) {
+      return;
+    }
+    console.log(selectedFamily.id);
+    console.log(data);
+  };
+
   return (
     <>
       <Typography variant="h1">Main registration</Typography>
@@ -47,6 +59,7 @@ const MainRegistration = () => {
           isOpen={isSidebarOpen}
           family={selectedFamily}
           onClose={() => setIsSidebarOpen(false)}
+          onEditFamily={onEditFamily}
         />
       )}
     </>

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -151,6 +151,10 @@ const Sessions = () => {
     setIsSidebarOpen(true);
   };
 
+  const onEditFamily = async () => {
+    // TODO: make put request
+  };
+
   return (
     <>
       <Box display="flex">
@@ -214,6 +218,7 @@ const Sessions = () => {
                   isOpen={isSidebarOpen}
                   family={selectedFamily}
                   onClose={() => setIsSidebarOpen(false)}
+                  onEditFamily={onEditFamily}
                 />
               )}
             </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2234,6 +2234,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/lodash@^4.14.171":
+  version "4.14.171"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.171.tgz#f01b3a5fe3499e34b622c362a46a609fdb23573b"
+  integrity sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg==
+
 "@types/long@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[sidebar - edit the notes section](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=065bfbbf004d4fd1b7cc9f4d518dc31d)
[reg form - notes question](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=9f92ab57ffd04c9a85d18160e86bb8e8)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- added the notes question to the registration form
- styled the notes question in the sidebar, and linked it to a stub function to update the family (to be linked up to a PUT request when [#93 on the backend](https://github.com/uwblueprint/project-read-backend/pull/93)) goes in
- added lodash for to use the debounce function for throttling ([docs](https://lodash.com/docs/#debounce)), which gives us the effect of saving on edit without making excessive api requests

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. backend needs to include [this PR](https://github.com/uwblueprint/project-read-backend/pull/91)
1. open the reg form and add notes when registering a new family
1. open the sidebar and check out the family's notes
    * editing shouldn't do anything yet, but we'll test that in an upcoming PR

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- styling, functionality

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
