### PR TITLE
Implement the current enrolment section in the sidebar

### DIFF
--- a/src/api/APIUtils.js
+++ b/src/api/APIUtils.js
@@ -31,3 +31,17 @@ export async function post(path, data) {
 
   return res.json();
 }
+
+export async function put(path, data) {
+  const token = await getIdToken();
+  const res = await fetch(url + path, {
+    method: "PUT",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+
+  return res.json();
+}

--- a/src/api/EnrolmentAPI.ts
+++ b/src/api/EnrolmentAPI.ts
@@ -1,9 +1,26 @@
 import * as APIUtils from "./APIUtils";
-import { EnrolmentFamilyRequest } from "./types";
+import {
+  EnrolmentFamilyRequest,
+  EnrolmentRequest,
+  EnrolmentResponse,
+} from "./types";
+
+export const enrolmentResponseToRequest = (
+  data: EnrolmentResponse
+): EnrolmentRequest => ({
+  ...data,
+  session: data.session.id,
+  preferred_class: data.preferred_class?.id || null,
+  enrolled_class: data.enrolled_class?.id || null,
+});
 
 const postEnrolment = (data: EnrolmentFamilyRequest) =>
   APIUtils.post("/enrolments/", data);
 
+const putEnrolment = (data: EnrolmentRequest) =>
+  APIUtils.put(`/enrolments/${data.id}/`, data);
+
 export default {
   postEnrolment,
+  putEnrolment,
 };

--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -18,17 +18,28 @@ export type ClassDetailResponse = Class & {
   families: FamilyListResponse[];
 };
 
-export type SessionListResponse = Pick<Session, "id" | "name">;
+export type SessionListResponse = Pick<Session, "id" | "name"> & {
+  classes: ClassListResponse[];
+};
 
 export type SessionDetailResponse = Session & {
   classes: ClassListResponse[];
   families: FamilyListResponse[];
 };
 
-export type EnrolmentResponse = Pick<Enrolment, "id" | "status"> & {
-  session: SessionListResponse | null;
+export type EnrolmentResponse = Pick<
+  Enrolment,
+  "id" | "status" | "students"
+> & {
+  session: SessionListResponse;
   preferred_class: ClassListResponse | null;
   enrolled_class: ClassListResponse | null;
+};
+
+export type EnrolmentRequest = Pick<Enrolment, "id" | "status" | "students"> & {
+  session: number;
+  preferred_class: number | null;
+  enrolled_class: number | null;
 };
 
 export type InteractionResponse = Interaction & {

--- a/src/components/common/status-chip/StatusChip.tsx
+++ b/src/components/common/status-chip/StatusChip.tsx
@@ -17,7 +17,12 @@ const StatusColourMap = new Map([
 ]);
 
 type Props = {
+  className?: string;
   status: EnrolmentStatus;
+};
+
+const defaultProps = {
+  className: "",
 };
 
 const useStyles = makeStyles<Theme, Props>(() => ({
@@ -36,9 +41,11 @@ const useStyles = makeStyles<Theme, Props>(() => ({
   },
 }));
 
-const StatusChip = ({ status }: Props) => {
+const StatusChip = ({ className, status }: Props) => {
   const classes = useStyles({ status });
-  return <Chip label={status} className={classes.chip} />;
+  return <Chip label={status} className={`${classes.chip} ${className}`} />;
 };
+
+StatusChip.defaultProps = defaultProps;
 
 export default StatusChip;

--- a/src/components/families/family-sidebar/FamilySidebar.tsx
+++ b/src/components/families/family-sidebar/FamilySidebar.tsx
@@ -14,12 +14,17 @@ import { Add, Edit } from "@material-ui/icons";
 import debounce from "lodash/debounce";
 import moment from "moment";
 
-import { FamilyDetailResponse, FamilyRequest } from "api/types";
+import {
+  FamilyDetailResponse,
+  FamilyRequest,
+  EnrolmentRequest,
+} from "api/types";
 import {
   FamilyFormData,
   familyResponseToFamilyFormData,
 } from "components/families/family-form/utils";
 
+import EnrolmentForm from "./enrolment-form";
 import FamilySidebarCard from "./family-sidebar-card";
 import FamilySidebarForm, { familySidebarFormId } from "./family-sidebar-form";
 
@@ -78,11 +83,18 @@ const useStyles = makeStyles((theme) => ({
 type Props = {
   family: FamilyDetailResponse;
   isOpen: boolean;
+  onEditCurrentEnrolment: (enrolment: EnrolmentRequest) => void;
   onEditFamily: (family: FamilyRequest) => void;
   onClose: () => void;
 };
 
-const FamilySidebar = ({ family, isOpen, onClose, onEditFamily }: Props) => {
+const FamilySidebar = ({
+  family,
+  isOpen,
+  onClose,
+  onEditCurrentEnrolment,
+  onEditFamily,
+}: Props) => {
   const classes = useStyles();
   const sidebar = useRef<HTMLDivElement>(null);
 
@@ -163,7 +175,19 @@ const FamilySidebar = ({ family, isOpen, onClose, onEditFamily }: Props) => {
         <Typography variant="h2">
           {family.parent.first_name} {family.parent.last_name}
         </Typography>
-        <Divider variant="fullWidth" />
+
+        <Typography variant="h3" className={classes.heading}>
+          Enrolment
+        </Typography>
+        <EnrolmentForm
+          enrolment={family.current_enrolment}
+          onChange={onEditCurrentEnrolment}
+        />
+
+        <Box paddingTop={2}>
+          <Divider />
+        </Box>
+
         <Box position="relative">
           <Box position="absolute" top={8} right={0}>
             <IconButton

--- a/src/components/families/family-sidebar/enrolment-form/EnrolmentForm.tsx
+++ b/src/components/families/family-sidebar/enrolment-form/EnrolmentForm.tsx
@@ -58,7 +58,7 @@ const EnrolmentForm = ({ enrolment, onChange }: Props) => {
     <EnrolmentFormRow
       id={`${baseId}-session`}
       label="Session"
-      link={enrolment ? `/sessions/${enrolment.session}` : undefined}
+      link={enrolment && `/sessions/${enrolment.session.id}`}
     >
       <Box
         className={classes.inputBackground}
@@ -112,7 +112,10 @@ const EnrolmentForm = ({ enrolment, onChange }: Props) => {
       <EnrolmentFormRow
         id={`${baseId}-enrolled-class`}
         label="Class"
-        link={`/sessions/${enrolment.session}/classes/${enrolment.enrolled_class}`}
+        link={
+          enrolment.enrolled_class &&
+          `/sessions/${enrolment.session.id}/classes/${enrolment.enrolled_class.id}`
+        }
       >
         <ClassSelect
           id={`${baseId}-enrolled-class`}

--- a/src/components/families/family-sidebar/enrolment-form/EnrolmentForm.tsx
+++ b/src/components/families/family-sidebar/enrolment-form/EnrolmentForm.tsx
@@ -1,0 +1,146 @@
+import React from "react";
+
+import {
+  Box,
+  InputBase,
+  MenuItem,
+  Select,
+  Theme,
+  Typography,
+} from "@material-ui/core";
+import { makeStyles } from "@material-ui/styles";
+
+import { enrolmentResponseToRequest } from "api/EnrolmentAPI";
+import { EnrolmentRequest, EnrolmentResponse } from "api/types";
+import FormRow from "components/common/form-row";
+import StatusChip from "components/common/status-chip";
+import EnrolmentStatus from "constants/EnrolmentStatus";
+import QuestionType from "constants/QuestionType";
+
+import ClassSelect from "./class-select";
+import EnrolmentFormRow from "./enrolment-form-row";
+
+const baseId = "enrolment-select";
+
+const useStyles = makeStyles((theme: Theme) => ({
+  input: {
+    cursor: "pointer",
+    height: 40,
+    fontSize: 14,
+    marginBottom: 4,
+    marginTop: 4,
+  },
+  inputBackground: {
+    backgroundColor: theme.palette.backgroundSecondary.default,
+    borderRadius: 4,
+  },
+  select: {
+    paddingBottom: 4,
+    paddingTop: 4,
+    paddingLeft: 4,
+    paddingRight: 32,
+    width: "100%",
+  },
+  statusChip: {
+    cursor: "pointer",
+  },
+}));
+
+type Props = {
+  enrolment: EnrolmentResponse | null;
+  onChange: (enrolment: EnrolmentRequest) => void;
+};
+
+const EnrolmentForm = ({ enrolment, onChange }: Props) => {
+  const classes = useStyles();
+
+  const SessionRow = () => (
+    <EnrolmentFormRow
+      id={`${baseId}-session`}
+      label="Session"
+      link={enrolment ? `/sessions/${enrolment.session}` : undefined}
+    >
+      <Box
+        className={classes.inputBackground}
+        marginY={0.25}
+        paddingX={2}
+        paddingY={1.25}
+      >
+        <Typography variant="body2">
+          {enrolment ? enrolment.session.name : "Not enrolled"}
+        </Typography>
+      </Box>
+    </EnrolmentFormRow>
+  );
+
+  if (enrolment === null) {
+    return <SessionRow />;
+  }
+
+  return (
+    <>
+      <Box>
+        <FormRow
+          dense
+          id={`${baseId}-status`}
+          label="Status"
+          questionType={QuestionType.MULTIPLE_CHOICE}
+        >
+          <Select
+            input={<InputBase className={classes.input} />}
+            labelId={`${baseId}-status`}
+            onChange={(e) =>
+              onChange({
+                ...enrolmentResponseToRequest(enrolment),
+                status: e.target.value as EnrolmentStatus,
+              })
+            }
+            SelectDisplayProps={{ className: classes.select }}
+            value={enrolment.status}
+          >
+            {Object.values(EnrolmentStatus)
+              .filter((status) => status !== EnrolmentStatus.UNASSIGNED)
+              .map((status) => (
+                <MenuItem value={status}>
+                  <StatusChip className={classes.statusChip} status={status} />
+                </MenuItem>
+              ))}
+          </Select>
+        </FormRow>
+      </Box>
+      <SessionRow />
+      <EnrolmentFormRow
+        id={`${baseId}-enrolled-class`}
+        label="Class"
+        link={`/sessions/${enrolment.session}/classes/${enrolment.enrolled_class}`}
+      >
+        <ClassSelect
+          id={`${baseId}-enrolled-class`}
+          onChange={(enrolled_class) =>
+            onChange({
+              ...enrolmentResponseToRequest(enrolment),
+              enrolled_class,
+            })
+          }
+          options={enrolment.session.classes}
+          value={enrolment.enrolled_class?.id || null}
+        />
+      </EnrolmentFormRow>
+      <EnrolmentFormRow id={`${baseId}-preferred-class`} label="Preferences">
+        <ClassSelect
+          id={`${baseId}-preferred-class`}
+          onChange={(preferred_class) =>
+            onChange({
+              ...enrolmentResponseToRequest(enrolment),
+              preferred_class,
+            })
+          }
+          options={enrolment.session.classes}
+          value={enrolment.preferred_class?.id || null}
+        />
+      </EnrolmentFormRow>
+    </>
+  );
+};
+
+export default EnrolmentForm;

--- a/src/components/families/family-sidebar/enrolment-form/class-select/ClassSelect.tsx
+++ b/src/components/families/family-sidebar/enrolment-form/class-select/ClassSelect.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+
+import { Select, InputBase, MenuItem, Theme } from "@material-ui/core";
+import { makeStyles } from "@material-ui/styles";
+
+import { ClassListResponse } from "api/types";
+
+const baseId = "enrolment-select";
+
+const useStyles = makeStyles((theme: Theme) => ({
+  input: {
+    backgroundColor: theme.palette.backgroundSecondary.default,
+    borderRadius: 4,
+    cursor: "pointer",
+    fontSize: 14,
+    height: 40,
+    marginBottom: 2,
+    marginTop: 2,
+  },
+  menuItem: {
+    fontSize: 14,
+    height: 40,
+  },
+  select: {
+    borderRadius: 4,
+    paddingBottom: 4,
+    paddingTop: 4,
+    paddingLeft: 16,
+    paddingRight: 32,
+    width: "100%",
+  },
+}));
+
+type Props = {
+  id: string;
+  onChange: (id: number) => void;
+  options: ClassListResponse[];
+  value: number | null;
+};
+
+const ClassSelect = ({ id, onChange, options, value }: Props) => {
+  const classes = useStyles();
+  return (
+    <Select
+      displayEmpty
+      fullWidth
+      input={<InputBase className={classes.input} />}
+      labelId={`${baseId}-${id}`}
+      onChange={(e) => onChange!(e.target.value as number)}
+      SelectDisplayProps={{
+        className: classes.select,
+      }}
+      value={value || ""}
+    >
+      <MenuItem className={classes.menuItem} value="">
+        None
+      </MenuItem>
+      {options?.map((option) => (
+        <MenuItem className={classes.menuItem} value={option.id}>
+          {option.name}
+        </MenuItem>
+      ))}
+    </Select>
+  );
+};
+
+export default ClassSelect;

--- a/src/components/families/family-sidebar/enrolment-form/class-select/index.ts
+++ b/src/components/families/family-sidebar/enrolment-form/class-select/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ClassSelect";

--- a/src/components/families/family-sidebar/enrolment-form/enrolment-form-row/EnrolmentFormRow.tsx
+++ b/src/components/families/family-sidebar/enrolment-form/enrolment-form-row/EnrolmentFormRow.tsx
@@ -1,0 +1,65 @@
+import React, { ReactNode } from "react";
+
+import { Box, IconButton } from "@material-ui/core";
+import { OpenInNew } from "@material-ui/icons";
+import { makeStyles } from "@material-ui/styles";
+import { Link } from "react-router-dom";
+
+import FormRow from "components/common/form-row";
+import QuestionType from "constants/QuestionType";
+
+const baseId = "enrolment-select";
+
+const useStyles = makeStyles(() => ({
+  linkButton: {
+    height: 40,
+    width: 40,
+    "& svg": {
+      height: 20,
+      width: 20,
+    },
+  },
+}));
+
+type Props = {
+  children: ReactNode;
+  id: string;
+  label: string;
+  link?: string;
+};
+
+const defaultProps = {
+  link: "",
+};
+
+const EnrolmentSelectFormRow = ({ children, id, label, link }: Props) => {
+  const classes = useStyles();
+
+  return (
+    <Box display="flex" flexDirection="row">
+      <Box width={280}>
+        <FormRow
+          dense
+          id={`${baseId}-${id}`}
+          label={label}
+          questionType={QuestionType.MULTIPLE_CHOICE}
+        >
+          {children}
+        </FormRow>
+      </Box>
+      {link && (
+        <Box marginLeft={1} marginY={0.25}>
+          <Link to={link} target="blank">
+            <IconButton className={classes.linkButton}>
+              <OpenInNew color="primary" />
+            </IconButton>
+          </Link>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+EnrolmentSelectFormRow.defaultProps = defaultProps;
+
+export default EnrolmentSelectFormRow;

--- a/src/components/families/family-sidebar/enrolment-form/enrolment-form-row/EnrolmentFormRow.tsx
+++ b/src/components/families/family-sidebar/enrolment-form/enrolment-form-row/EnrolmentFormRow.tsx
@@ -32,7 +32,7 @@ const defaultProps = {
   link: null,
 };
 
-const EnrolmentSelectFormRow = ({ children, id, label, link }: Props) => {
+const EnrolmentFormRow = ({ children, id, label, link }: Props) => {
   const classes = useStyles();
 
   return (
@@ -60,6 +60,6 @@ const EnrolmentSelectFormRow = ({ children, id, label, link }: Props) => {
   );
 };
 
-EnrolmentSelectFormRow.defaultProps = defaultProps;
+EnrolmentFormRow.defaultProps = defaultProps;
 
-export default EnrolmentSelectFormRow;
+export default EnrolmentFormRow;

--- a/src/components/families/family-sidebar/enrolment-form/enrolment-form-row/EnrolmentFormRow.tsx
+++ b/src/components/families/family-sidebar/enrolment-form/enrolment-form-row/EnrolmentFormRow.tsx
@@ -25,11 +25,11 @@ type Props = {
   children: ReactNode;
   id: string;
   label: string;
-  link?: string;
+  link?: string | null;
 };
 
 const defaultProps = {
-  link: "",
+  link: null,
 };
 
 const EnrolmentSelectFormRow = ({ children, id, label, link }: Props) => {

--- a/src/components/families/family-sidebar/enrolment-form/enrolment-form-row/index.ts
+++ b/src/components/families/family-sidebar/enrolment-form/enrolment-form-row/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./EnrolmentFormRow";

--- a/src/components/families/family-sidebar/enrolment-form/index.ts
+++ b/src/components/families/family-sidebar/enrolment-form/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./EnrolmentForm";

--- a/src/pages/MainRegistration.tsx
+++ b/src/pages/MainRegistration.tsx
@@ -2,8 +2,13 @@ import React, { useEffect, useState } from "react";
 
 import { Typography } from "@material-ui/core";
 
+import EnrolmentAPI from "api/EnrolmentAPI";
 import FamilyAPI from "api/FamilyAPI";
-import { FamilyDetailResponse, FamilyListResponse } from "api/types";
+import {
+  EnrolmentRequest,
+  FamilyDetailResponse,
+  FamilyListResponse,
+} from "api/types";
 import FamilySidebar from "components/families/family-sidebar";
 import FamilyTable from "components/families/family-table";
 import { DefaultFields } from "constants/DefaultFields";
@@ -16,11 +21,10 @@ const MainRegistration = () => {
     setSelectedFamily,
   ] = useState<FamilyDetailResponse | null>(null);
 
+  const resetFamilies = async () => setFamilies(await FamilyAPI.getFamilies());
+
   useEffect(() => {
-    async function fetchFamilies() {
-      setFamilies(await FamilyAPI.getFamilies());
-    }
-    fetchFamilies();
+    resetFamilies();
   }, []);
 
   const onSelectFamily = async (id: number) => {
@@ -29,7 +33,23 @@ const MainRegistration = () => {
     setIsSidebarOpen(true);
   };
 
-  const onEditFamily = async () => {};
+  const onEditFamily = async () => {
+    if (selectedFamily === null) {
+      return;
+    }
+    resetFamilies();
+  };
+
+  const onEditFamilyCurrentEnrolment = async (data: EnrolmentRequest) => {
+    if (selectedFamily === null || selectedFamily.current_enrolment === null) {
+      return;
+    }
+    setSelectedFamily({
+      ...selectedFamily,
+      current_enrolment: await EnrolmentAPI.putEnrolment(data),
+    });
+    resetFamilies();
+  };
 
   return (
     <>
@@ -49,6 +69,7 @@ const MainRegistration = () => {
           isOpen={isSidebarOpen}
           family={selectedFamily}
           onClose={() => setIsSidebarOpen(false)}
+          onEditCurrentEnrolment={onEditFamilyCurrentEnrolment}
           onEditFamily={onEditFamily}
         />
       )}

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -13,6 +13,7 @@ import { Add } from "@material-ui/icons/";
 import { useHistory, useParams } from "react-router-dom";
 
 import ClassAPI from "api/ClassAPI";
+import EnrolmentAPI from "api/EnrolmentAPI";
 import FamilyAPI from "api/FamilyAPI";
 import SessionAPI from "api/SessionAPI";
 import {
@@ -21,6 +22,7 @@ import {
   SessionDetailResponse,
   FamilyListResponse,
   FamilyDetailResponse,
+  EnrolmentRequest,
 } from "api/types";
 import FamilySidebar from "components/families/family-sidebar";
 import FamilyTable from "components/families/family-table";
@@ -96,20 +98,21 @@ const Sessions = () => {
     }
   }, [sessionId]);
 
+  const resetClass = async (id: number) => {
+    const classObj = await ClassAPI.getClass(id);
+    setClassesMap(
+      (prevMap) => new Map([...Array.from(prevMap), [classObj.id, classObj]])
+    );
+  };
+
   useEffect(() => {
-    const fetchClass = async (id: number) => {
-      const classObj = await ClassAPI.getClass(id);
-      setClassesMap(
-        (prevMap) => new Map([...Array.from(prevMap), [classObj.id, classObj]])
-      );
-    };
     if (classId === undefined) {
       setClassTabIndex(ALL_CLASSES_TAB_INDEX);
       return;
     }
     const classIdNumber = Number(classId);
     if (!classesMap.has(classIdNumber)) {
-      fetchClass(classIdNumber);
+      resetClass(classIdNumber);
     }
     setClassTabIndex(classIdNumber);
   }, [classId]);
@@ -153,6 +156,22 @@ const Sessions = () => {
 
   const onEditFamily = async () => {
     // TODO: make put request
+  };
+
+  const onEditFamilyCurrentEnrolment = async (data: EnrolmentRequest) => {
+    if (selectedFamily === null || selectedFamily.current_enrolment === null) {
+      return;
+    }
+    setSelectedFamily({
+      ...selectedFamily,
+      current_enrolment: await EnrolmentAPI.putEnrolment(data),
+    });
+    if (selectedSession) {
+      updateSelectedSession(selectedSession.id);
+    }
+    classesMap.forEach(({ id }) => {
+      resetClass(id);
+    });
   };
 
   return (
@@ -218,6 +237,7 @@ const Sessions = () => {
                   isOpen={isSidebarOpen}
                   family={selectedFamily}
                   onClose={() => setIsSidebarOpen(false)}
+                  onEditCurrentEnrolment={onEditFamilyCurrentEnrolment}
                   onEditFamily={onEditFamily}
                 />
               )}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -75,4 +75,5 @@ export type Class = {
 export type Enrolment = {
   id: number;
   status: EnrolmentStatus;
+  students: number[];
 };


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Edit status, enrolled class, preferred class](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=60db38ca6390432ab42cfbe3cbf1137a)
[Dropdown components](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=3addc82be91f4bb29116dfb9682e48d9)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- added components for the current enrolment section:
  - EnrolmentForm
  - EnrolmentFormRow
  - ClassSelect
- added a util function for put endpoints, registered the put enrolment endpoint
- implemented logic to edit + save changes to the enrolment, and refresh the family lists

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. backend needs to include [this PR](https://github.com/uwblueprint/project-read-backend/pull/96)
1. open the sidebar from the registration/sessions pages
2. play around with editing! it should update in the sidebar as well as the table

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- testing & code quality

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
