### PR TITLE
Add background colour for enrolled classes in the family table

### DIFF
--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -12,7 +12,7 @@ import {
 
 export type UserResponse = Pick<User, "id" | "first_name" | "last_name">;
 
-export type ClassListResponse = Pick<Class, "id" | "name">;
+export type ClassListResponse = Pick<Class, "id" | "name" | "colour">;
 
 export type ClassDetailResponse = Class & {
   families: FamilyListResponse[];

--- a/src/components/families/family-table/FamilyTable.tsx
+++ b/src/components/families/family-table/FamilyTable.tsx
@@ -182,6 +182,30 @@ const FamilyTable = ({
     };
   };
 
+  const enrolledClassColumn: MUIDataTableColumn = {
+    name: DefaultFields.ENROLLED_CLASS.id,
+    label: DefaultFields.ENROLLED_CLASS.name,
+    options: {
+      customBodyRender: (value) => (
+        <Typography noWrap variant="body2">
+          {value}
+        </Typography>
+      ),
+      searchable: false,
+      setCellProps: (cellValue, rowIndex) => {
+        const classColour =
+          families[rowIndex].enrolment?.enrolled_class?.colour || "ffffff00";
+        return {
+          style: {
+            backgroundColor: `#${classColour}`,
+            paddingLeft: 16,
+            paddingRight: 16,
+          },
+        };
+      },
+    },
+  };
+
   const columns: MUIDataTableColumn[] = [
     // hidden ID column
     idColumn,
@@ -207,7 +231,12 @@ const FamilyTable = ({
     ...parentDynamicFields.map((field) => getColumn(field, true)),
 
     // enrolment columns
-    ...enrolmentFields.map((field) => getColumn(field, false)),
+    ...enrolmentFields
+      .filter((field) => field !== DefaultFields.ENROLLED_CLASS)
+      .map((field) => getColumn(field, false)),
+    ...(enrolmentFields.includes(DefaultFields.ENROLLED_CLASS)
+      ? [enrolledClassColumn]
+      : []),
     statusColumn,
   ];
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -68,8 +68,9 @@ export type Interaction = {
 
 export type Class = {
   id: number;
-  name: string;
   attendance: Attendance[];
+  colour: string;
+  name: string;
 };
 
 export type Enrolment = {


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[colour coding for classes](https://www.notion.so/uwblueprintexecs/Sprint-3-481954865bf444498031befeafaad95a?p=a5284df786aa4758961faee78ab335f9)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- defined an `enrolledClassColumn` where the background colour is the class object's `colour` property

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. run `load_initial_data` with [#101 on the backend](https://github.com/uwblueprint/project-read-backend/pull/101)
1. open the registration table & sessions page (all classes) → the classes should have a bg colour! 🎨

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- testing, and checking out the colours 🎨 

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
