### PR TITLE
Attendance table

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     ]
   },
   "devDependencies": {
-    "@types/lodash": "^4.14.171",
+    "@types/lodash": "^4.14.172",
     "@types/mui-datatables": "^3.7.3",
     "@types/react-router-dom": "^5.1.7",
     "@typescript-eslint/eslint-plugin": "^4.22.1",

--- a/src/api/ClassAPI.ts
+++ b/src/api/ClassAPI.ts
@@ -1,7 +1,10 @@
 import * as APIUtils from "./APIUtils";
-import { ClassDetailResponse } from "./types";
+import { ClassDetailResponse, ClassRequest } from "./types";
 
 const getClass = (id: number): Promise<ClassDetailResponse> =>
   APIUtils.get(`/classes/${id}`) as Promise<ClassDetailResponse>;
 
-export default { getClass };
+const putClass = (data: ClassRequest): Promise<ClassDetailResponse> =>
+  APIUtils.put(`/classes/${data.id}/`, data);
+
+export default { getClass, putClass };

--- a/src/api/ClassAPI.ts
+++ b/src/api/ClassAPI.ts
@@ -5,6 +5,6 @@ const getClass = (id: number): Promise<ClassDetailResponse> =>
   APIUtils.get(`/classes/${id}`) as Promise<ClassDetailResponse>;
 
 const putClass = (data: ClassRequest): Promise<ClassDetailResponse> =>
-  APIUtils.put(`/classes/${data.id}/`, data);
+  APIUtils.put(`/classes/${data.id}/`, data) as Promise<ClassDetailResponse>;
 
 export default { getClass, putClass };

--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -21,6 +21,7 @@ export type ClassDetailResponse = Class & {
 export type SessionListResponse = Pick<Session, "id" | "name"> & {
   classes: ClassListResponse[];
 };
+export type ClassRequest = ClassDetailResponse;
 
 export type SessionDetailResponse = Session & {
   classes: ClassListResponse[];

--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -65,6 +65,7 @@ export type FamilyDetailResponse = Pick<
 export type FamilyListResponse = Pick<
   Family,
   | DefaultFieldKey.CHILDREN
+  | DefaultFieldKey.GUESTS
   | DefaultFieldKey.EMAIL
   | DefaultFieldKey.ID
   | DefaultFieldKey.NUM_CHILDREN

--- a/src/components/sessions/session-detail-view/AttendanceTable.tsx
+++ b/src/components/sessions/session-detail-view/AttendanceTable.tsx
@@ -1,0 +1,199 @@
+import React, { useEffect, useState } from "react";
+
+import {
+  Button,
+  Checkbox,
+  createMuiTheme,
+  MuiThemeProvider,
+} from "@material-ui/core";
+import _ from "lodash";
+import MUIDataTable, {
+  MUIDataTableColumn,
+  MUIDataTableOptions,
+} from "mui-datatables";
+
+import { ClassDetailResponse, ClassRequest } from "api/types";
+
+type AttendanceTableRow = {
+  id: string;
+  first_name: string;
+  last_name: string;
+  [key: string]: string;
+};
+
+type AttendanceTableProps = {
+  classObj: ClassDetailResponse;
+  isEditing: boolean;
+  onSubmit: (data: ClassRequest) => void;
+};
+
+const monthNames = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+const AttendanceTable = ({
+  classObj,
+  isEditing,
+  onSubmit,
+}: AttendanceTableProps) => {
+  const [data, setData] = useState<ClassRequest>(_.cloneDeep(classObj));
+  const [tableRows, setTableRows] = useState<AttendanceTableRow[]>([]);
+
+  const handleCheckboxOnClick = (id: number, date: string) => {
+    const dateIndex = data.attendance.findIndex(
+      (element: { date: string }) => element.date === date
+    );
+    const idIndex = data.attendance[dateIndex].attendees.findIndex(
+      (element) => element === id
+    );
+    const newData: ClassDetailResponse = _.cloneDeep(data);
+    if (idIndex === -1) {
+      newData.attendance[dateIndex].attendees.push(id);
+    } else {
+      newData.attendance[dateIndex].attendees.splice(idIndex, 1);
+    }
+    setData(newData);
+  };
+
+  const getMuiTheme = () =>
+    createMuiTheme({
+      overrides: {
+        MUIDataTableToolbar: {
+          actions: {
+            display: "flex",
+            flexDirection: "row",
+            flex: "initial",
+          },
+        },
+      },
+    });
+
+  const options: MUIDataTableOptions = {
+    responsive: "standard",
+    rowsPerPage: 25,
+    rowsPerPageOptions: [25, 50, 100],
+    selectableRows: "none",
+    elevation: 0,
+    customToolbar: () => (
+      <Button
+        variant="outlined"
+        color={!isEditing ? "default" : "primary"}
+        onClick={() => onSubmit(data)}
+        style={{ order: -1, height: 36, marginTop: 5, marginRight: 15 }}
+      >
+        {!isEditing ? "Take Attendance " : "Done Attendance "}
+        &#10003;
+      </Button>
+    ),
+  };
+
+  const getTableRows = (): AttendanceTableRow[] => {
+    const rows: AttendanceTableRow[][] = [];
+    const currFamily = classObj.families.flatMap((family) => {
+      const familyNames: AttendanceTableRow[] = [];
+      const parentRow: AttendanceTableRow = {
+        id: family.parent.id.toString(),
+        first_name: `${family.parent.first_name} (parent)`,
+        last_name: family.parent.last_name,
+      };
+      data.attendance.forEach((currClass) => {
+        parentRow[currClass.date] =
+          currClass.attendees.filter((id) => id === family.parent.id).length > 0
+            ? "yes"
+            : "no";
+      });
+      familyNames.push(parentRow);
+      family.children.forEach((child) => {
+        const childRow: AttendanceTableRow = {
+          id: child.id.toString(),
+          first_name: child.first_name,
+          last_name: child.last_name,
+        };
+        data.attendance.forEach((currClass) => {
+          childRow[currClass.date] =
+            currClass.attendees.filter((id) => id === child.id).length > 0
+              ? "yes"
+              : "no";
+        });
+        familyNames.push(childRow);
+      });
+      return familyNames;
+    });
+    rows.push(currFamily);
+    return rows.flat();
+  };
+
+  useEffect(() => {
+    setTableRows(getTableRows());
+  }, [data]);
+
+  const getTableColumns = (): MUIDataTableColumn[] => {
+    const idColumn: MUIDataTableColumn = {
+      name: "id",
+      options: { display: "excluded" },
+    };
+    const firstNameColumn: MUIDataTableColumn = {
+      name: "first_name",
+      label: "First Name",
+    };
+    const lastNameColumn: MUIDataTableColumn = {
+      name: "last_name",
+      label: "Last Name",
+    };
+    const dateColumns: MUIDataTableColumn[] = [];
+    data.attendance.forEach((currClass) => {
+      // eslint-disable-next-line prefer-template
+      const currDate = new Date(currClass.date + " ");
+      const dateColumn: MUIDataTableColumn = {
+        name: currClass.date,
+        label: `${monthNames[currDate.getMonth()]} ${String(
+          currDate.getDate()
+        )}`,
+        options: {
+          customBodyRender: (value, tableMeta) => (
+            <Checkbox
+              checked={value === "yes"}
+              disabled={!isEditing}
+              color="primary"
+              inputProps={{ "aria-label": "secondary checkbox" }}
+              onChange={() =>
+                handleCheckboxOnClick(
+                  Number(tableMeta.rowData[0]),
+                  currDate.toISOString().split("T")[0]
+                )
+              }
+            />
+          ),
+        },
+      };
+      dateColumns.push(dateColumn);
+    });
+    return [idColumn, firstNameColumn, lastNameColumn].concat(dateColumns);
+  };
+
+  return (
+    <>
+      <MuiThemeProvider theme={getMuiTheme()}>
+        <MUIDataTable
+          title=""
+          data={tableRows}
+          columns={getTableColumns()}
+          options={options}
+        />
+      </MuiThemeProvider>
+    </>
+  );
+};
+
+export default AttendanceTable;

--- a/src/components/sessions/session-detail-view/AttendanceTable.tsx
+++ b/src/components/sessions/session-detail-view/AttendanceTable.tsx
@@ -167,7 +167,6 @@ const AttendanceTable = ({
     };
     const dateColumns: MUIDataTableColumn[] = data.attendance.map(
       (currClass) => {
-        // eslint-disable-next-line prefer-template
         const dateColumn: MUIDataTableColumn = {
           name: currClass.date,
           label: moment(currClass.date).format("MMM D"),

--- a/src/components/sessions/session-detail-view/AttendanceTable.tsx
+++ b/src/components/sessions/session-detail-view/AttendanceTable.tsx
@@ -9,6 +9,7 @@ import {
 import CheckIcon from "@material-ui/icons/Check";
 import { makeStyles } from "@material-ui/styles";
 import _ from "lodash";
+import moment from "moment";
 import MUIDataTable, {
   MUIDataTableColumn,
   MUIDataTableOptions,
@@ -38,22 +39,12 @@ const useStyles = makeStyles(() => ({
     marginRight: 15,
     textTransform: "none",
   },
+  checkmark: {
+    height: "20px",
+    width: "20px",
+    marginLeft: "8px",
+  },
 }));
-
-const monthNames = [
-  "Jan",
-  "Feb",
-  "Mar",
-  "Apr",
-  "May",
-  "Jun",
-  "Jul",
-  "Aug",
-  "Sep",
-  "Oct",
-  "Nov",
-  "Dec",
-];
 
 const AttendanceTable = ({
   classObj,
@@ -106,7 +97,7 @@ const AttendanceTable = ({
         className={classes.button}
       >
         {!isEditing ? "Take attendance " : "Done attendance "}
-        <CheckIcon />
+        <CheckIcon className={classes.checkmark} />
       </Button>
     ),
   };
@@ -120,37 +111,36 @@ const AttendanceTable = ({
         last_name: family.parent.last_name,
       };
       data.attendance.forEach((currClass) => {
-        parentRow[currClass.date] =
-          currClass.attendees.filter((id) => id === family.parent.id).length > 0
-            ? "yes"
-            : "no";
+        parentRow[currClass.date] = currClass.attendees.includes(
+          family.parent.id
+        )
+          ? "yes"
+          : "no";
       });
       rows.push(parentRow);
       family.children.forEach((child) => {
         const childRow: AttendanceTableRow = {
           id: child.id.toString(),
-          first_name: child.first_name,
+          first_name: `${child.first_name} (child)`,
           last_name: child.last_name,
         };
         data.attendance.forEach((currClass) => {
-          childRow[currClass.date] =
-            currClass.attendees.filter((id) => id === child.id).length > 0
-              ? "yes"
-              : "no";
+          childRow[currClass.date] = currClass.attendees.includes(child.id)
+            ? "yes"
+            : "no";
         });
         rows.push(childRow);
       });
       family.guests.forEach((guest) => {
         const guestRow: AttendanceTableRow = {
           id: guest.id.toString(),
-          first_name: guest.first_name,
+          first_name: `${guest.first_name} (guest)`,
           last_name: guest.last_name,
         };
         data.attendance.forEach((currClass) => {
-          guestRow[currClass.date] =
-            currClass.attendees.filter((id) => id === guest.id).length > 0
-              ? "yes"
-              : "no";
+          guestRow[currClass.date] = currClass.attendees.includes(guest.id)
+            ? "yes"
+            : "no";
         });
         rows.push(guestRow);
       });
@@ -178,12 +168,9 @@ const AttendanceTable = ({
     const dateColumns: MUIDataTableColumn[] = data.attendance.map(
       (currClass) => {
         // eslint-disable-next-line prefer-template
-        const currDate = new Date(currClass.date + " ");
         const dateColumn: MUIDataTableColumn = {
           name: currClass.date,
-          label: `${monthNames[currDate.getMonth()]} ${String(
-            currDate.getDate()
-          )}`,
+          label: moment(currClass.date).format("MMM D"),
           options: {
             customBodyRender: (value, tableMeta) => (
               <Checkbox

--- a/src/constants/DefaultFieldKey.ts
+++ b/src/constants/DefaultFieldKey.ts
@@ -2,6 +2,7 @@ enum DefaultFieldKey {
   ADDRESS = "address",
   CELL_NUMBER = "cell_number",
   CHILDREN = "children",
+  GUESTS = "guests",
   DATE_OF_BIRTH = "date_of_birth",
   ENROLLED_CLASS = "enrolled_class",
   EMAIL = "email",

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -186,8 +186,9 @@ const Sessions = () => {
     setIsTakingAttendance(!isEditingAttendance);
   };
 
-  const onSelectFamily = async (id: number) => {
-    const family = await FamilyAPI.getFamilyById(id);
+  const onSelectFamily = async (id: number | null) => {
+    setIsLoadingFamily(true);
+    const family = id ? await FamilyAPI.getFamilyById(id) : null;
     setSelectedFamily(family);
     setIsLoadingFamily(false);
   };
@@ -249,7 +250,7 @@ const Sessions = () => {
             family={selectedFamily}
             onClose={() => setIsSidebarOpen(false)}
             onEditCurrentEnrolment={onEditFamilyCurrentEnrolment}
-            onEditFamily={onEditFamily}
+            onSaveFamily={onSaveFamily}
           />
         )}
       </>

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -297,28 +297,30 @@ const Sessions = () => {
         </Box>
         {selectedSession && (
           <>
-            <FormControl variant="outlined">
-              <InputLabel id="view">View</InputLabel>
-              <Select
-                id="select"
-                label="view"
-                labelId="view"
-                value={!isOnAttendanceView ? "default" : "attendance"}
-              >
-                <MenuItem
-                  value="default"
-                  onClick={() => setAttendanceView(false)}
+            {classTabIndex !== 0 && (
+              <FormControl variant="outlined">
+                <InputLabel id="view">View</InputLabel>
+                <Select
+                  id="select"
+                  label="view"
+                  labelId="view"
+                  value={!isOnAttendanceView ? "default" : "attendance"}
                 >
-                  Default view
-                </MenuItem>
-                <MenuItem
-                  value="attendance"
-                  onClick={() => setAttendanceView(true)}
-                >
-                  Attendance view
-                </MenuItem>
-              </Select>
-            </FormControl>
+                  <MenuItem
+                    value="default"
+                    onClick={() => setAttendanceView(false)}
+                  >
+                    Default view
+                  </MenuItem>
+                  <MenuItem
+                    value="attendance"
+                    onClick={() => setAttendanceView(true)}
+                  >
+                    Attendance view
+                  </MenuItem>
+                </Select>
+              </FormControl>
+            )}
             <Box flexShrink={0}>
               <Button
                 variant="outlined"

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -11,6 +11,7 @@ import {
   Typography,
 } from "@material-ui/core";
 import { Add } from "@material-ui/icons/";
+import { makeStyles } from "@material-ui/styles";
 import { useHistory, useParams } from "react-router-dom";
 
 import ClassAPI from "api/ClassAPI";
@@ -43,12 +44,19 @@ const NEW_SESSION = -1;
 const isOnAllClassesTab = (classTabIndex: number) =>
   classTabIndex === ALL_CLASSES_TAB_INDEX;
 
+const useStyles = makeStyles(() => ({
+  input: {
+    marginLeft: "20px",
+  },
+}));
+
 type Params = {
   classId: string | undefined;
   sessionId: string | undefined;
 };
 
 const Sessions = () => {
+  const classes = useStyles();
   const history = useHistory();
   const { classId, sessionId } = useParams<Params>();
   const [sessions, setSessions] = useState<SessionListResponse[]>([]);
@@ -61,8 +69,8 @@ const Sessions = () => {
   );
   const [classTabIndex, setClassTabIndex] = useState(ALL_CLASSES_TAB_INDEX);
   const [displayRegDialog, setDisplayRegDialog] = useState(false);
-  const [attendanceView, setAttendanceView] = useState(false);
-  const [isTakingAttendance, setIsTakingAttendance] = useState(false);
+  const [isOnAttendanceView, setAttendanceView] = useState(false);
+  const [isEditingAttendance, setIsTakingAttendance] = useState(false);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [
     selectedFamily,
@@ -167,7 +175,7 @@ const Sessions = () => {
 
   useEffect(() => {
     setIsTakingAttendance(false);
-  }, [attendanceView]);
+  }, [isOnAttendanceView]);
 
   const onSubmitAttendance = async (classObj: ClassRequest) => {
     const updatedClass = await ClassAPI.putClass(classObj);
@@ -175,7 +183,7 @@ const Sessions = () => {
       (prevMap) =>
         new Map([...Array.from(prevMap), [classObj.id, updatedClass]])
     );
-    setIsTakingAttendance(!isTakingAttendance);
+    setIsTakingAttendance(!isEditingAttendance);
   };
 
   const onSelectFamily = async (id: number) => {
@@ -214,11 +222,11 @@ const Sessions = () => {
 
   const getClassView = () => {
     const selectedClass = classesMap.get(classTabIndex);
-    if (attendanceView && selectedClass) {
+    if (isOnAttendanceView && selectedClass) {
       return (
         <AttendanceTable
           classObj={selectedClass}
-          isEditing={isTakingAttendance}
+          isEditing={isEditingAttendance}
           onSubmit={onSubmitAttendance}
         />
       );
@@ -295,7 +303,7 @@ const Sessions = () => {
                 id="select"
                 label="view"
                 labelId="view"
-                value={!attendanceView ? "default" : "attendance"}
+                value={!isOnAttendanceView ? "default" : "attendance"}
               >
                 <MenuItem
                   value="default"
@@ -315,7 +323,7 @@ const Sessions = () => {
               <Button
                 variant="outlined"
                 onClick={handleOpenFormDialog}
-                style={{ marginLeft: "20px", height: "56px" }}
+                className={classes.input}
               >
                 Add a client &nbsp;
                 <Add />

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -242,7 +242,10 @@ const Sessions = () => {
               : []
           }
           shouldDisplayDynamicFields={false}
-          onSelectFamily={onSelectFamily}
+          onSelectFamily={async (id) => {
+            await onSelectFamily(id);
+            setIsSidebarOpen(true);
+          }}
         />
         {selectedFamily && (
           <FamilySidebar

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -45,7 +45,7 @@ const isOnAllClassesTab = (classTabIndex: number) =>
   classTabIndex === ALL_CLASSES_TAB_INDEX;
 
 const useStyles = makeStyles(() => ({
-  input: {
+  registerButton: {
     marginLeft: "20px",
   },
 }));
@@ -175,7 +175,7 @@ const Sessions = () => {
 
   useEffect(() => {
     setIsTakingAttendance(false);
-  }, [isOnAttendanceView]);
+  }, [isOnAttendanceView, classTabIndex]);
 
   const onSubmitAttendance = async (classObj: ClassRequest) => {
     const updatedClass = await ClassAPI.putClass(classObj);
@@ -297,7 +297,7 @@ const Sessions = () => {
         </Box>
         {selectedSession && (
           <>
-            {classTabIndex !== 0 && (
+            {classTabIndex !== ALL_CLASSES_TAB_INDEX && (
               <FormControl variant="outlined">
                 <InputLabel id="view">View</InputLabel>
                 <Select
@@ -325,7 +325,7 @@ const Sessions = () => {
               <Button
                 variant="outlined"
                 onClick={handleOpenFormDialog}
-                className={classes.input}
+                className={classes.registerButton}
               >
                 Add a client &nbsp;
                 <Add />

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -48,6 +48,7 @@ export type Family = {
   [DefaultFieldKey.NOTES]: string;
   [DefaultFieldKey.NUM_CHILDREN]: number;
   [DefaultFieldKey.CHILDREN]: Student[];
+  [DefaultFieldKey.GUESTS]: Student[];
   [DefaultFieldKey.PHONE_NUMBER]: string;
   [DefaultFieldKey.PREFERRED_CONTACT]: string;
   [DefaultFieldKey.PREFERRED_NUMBER]: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2301,10 +2301,10 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/lodash@^4.14.171":
-  version "4.14.171"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.171.tgz#f01b3a5fe3499e34b622c362a46a609fdb23573b"
-  integrity sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg==
+"@types/lodash@^4.14.172":
+  version "4.14.172"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.172.tgz#aad774c28e7bfd7a67de25408e03ee5a8c3d028a"
+  integrity sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw==
 
 "@types/long@^4.0.1":
   version "4.0.1"


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[View the existing attendance data in the table](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=3de0966c975545ecbd4339b7ee42d99b)
[Allow taking attendance and saving it](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=1c6a8ceb97f94bffbbab3be1b424d944)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- To get guests to show up, I think we needed to add them to the family serializer found in this pr: https://github.com/uwblueprint/project-read-backend/pull/106
- Display attendance table when attendance view is selected
- Take attendance functionality when "take attendance" is selected, and saves when "done attendance" is clicked
- Note that parent rows are not yet coloured (put "parent" in brackets for now) and don't have an icon

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Go to attendance view and look around :0
2. Click take attendance and play around :3

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- correctness

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
