### PR TITLE
Log users out only if they click "logout"

### DIFF
--- a/src/shared/Navbar.tsx
+++ b/src/shared/Navbar.tsx
@@ -16,17 +16,16 @@ const useStyles = makeStyles(() => ({
 }));
 
 function Navbar() {
-  const [anchorEl, setAnchorEl] = React.useState(null);
+  const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
   const classes = useStyles();
   const history = useHistory();
 
-  const handleClick = (event) => {
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
   };
 
   const handleClose = () => {
     setAnchorEl(null);
-    app.auth().signOut();
   };
 
   return (
@@ -44,8 +43,24 @@ function Navbar() {
             keepMounted
             open={Boolean(anchorEl)}
             onClose={handleClose}
+            getContentAnchorEl={null}
+            anchorOrigin={{
+              vertical: "bottom",
+              horizontal: "right",
+            }}
+            transformOrigin={{
+              vertical: "top",
+              horizontal: "right",
+            }}
           >
-            <MenuItem onClick={handleClose}>Logout</MenuItem>
+            <MenuItem
+              onClick={() => {
+                handleClose();
+                app.auth().signOut();
+              }}
+            >
+              Logout
+            </MenuItem>
           </Menu>
         </div>
       </Toolbar>

--- a/src/shared/ProjectREAD.jsx
+++ b/src/shared/ProjectREAD.jsx
@@ -5,12 +5,12 @@ import { Container } from "@material-ui/core";
 import { MuiPickersUtilsProvider } from "@material-ui/pickers";
 import { Redirect, Switch } from "react-router-dom";
 
-import Navbar from "components/Navbar";
 import { DynamicFieldsProvider } from "context/DynamicFieldsContext";
 import CreateSession from "pages/create-session";
 import MainRegistration from "pages/MainRegistration";
 import Sessions from "pages/Sessions";
 
+import Navbar from "./Navbar";
 import PrivateRoute from "./PrivateRoute";
 
 function ProjectREAD() {


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[logout button bug](https://www.notion.so/uwblueprintexecs/Sprint-3-481954865bf444498031befeafaad95a?p=53772c36096447c58d7b313a3b90c3f2)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- call `signOut()` only if users click the logout menu item
- update the file to tsx
- change the anchor/transform origin of the popover to match designs

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. open the app, click the account icon, and close the menu → should stay logged in
2. verify you can log out as expected

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- testing

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
