### PR TITLE
Update logic and add a success toast when users successfully register a new family

### DIFF
--- a/src/api/EnrolmentAPI.ts
+++ b/src/api/EnrolmentAPI.ts
@@ -1,6 +1,7 @@
 import * as APIUtils from "./APIUtils";
 import {
   EnrolmentFamilyRequest,
+  EnrolmentFamilyResponse,
   EnrolmentRequest,
   EnrolmentResponse,
 } from "./types";
@@ -16,8 +17,8 @@ export const enrolmentResponseToRequest = (
 
 const postEnrolment = (
   data: EnrolmentFamilyRequest
-): Promise<EnrolmentResponse> =>
-  APIUtils.post("/enrolments/", data) as Promise<EnrolmentResponse>;
+): Promise<EnrolmentFamilyResponse> =>
+  APIUtils.post("/enrolments/", data) as Promise<EnrolmentFamilyResponse>;
 
 const putEnrolment = (data: EnrolmentRequest): Promise<EnrolmentResponse> =>
   APIUtils.put(`/enrolments/${data.id}/`, data) as Promise<EnrolmentResponse>;

--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -121,6 +121,12 @@ export type EnrolmentFamilyRequest = Pick<Enrolment, "status"> & {
   preferred_class: number | null;
 };
 
+export type EnrolmentFamilyResponse = Pick<Enrolment, "status"> & {
+  family: FamilyDetailResponse;
+  session: number;
+  preferred_class: number | null;
+};
+
 export type DynamicFieldsResponse = {
   parent_fields: DynamicField[];
   child_fields: DynamicField[];

--- a/src/components/registration/RegistrationDialog.tsx
+++ b/src/components/registration/RegistrationDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { ReactNode, useEffect, useState } from "react";
 
 import {
   Box,
@@ -13,16 +13,10 @@ import { makeStyles } from "@material-ui/core/styles";
 import { Close, NavigateBefore } from "@material-ui/icons";
 
 import FamilyAPI from "api/FamilyAPI";
-import {
-  FamilyDetailResponse,
-  FamilySearchResponse,
-  SessionDetailResponse,
-} from "api/types";
+import { FamilySearchResponse } from "api/types";
 import RoundedOutlinedButton from "components/common/rounded-outlined-button";
 import FamilySearchResultsTable from "components/family-search/family-search-results-table";
 import StudentSearchBar from "components/family-search/student-search-bar";
-
-import RegistrationForm from "./registration-form";
 
 const useStyles = makeStyles((theme) => ({
   closeButton: {
@@ -45,10 +39,16 @@ const useStyles = makeStyles((theme) => ({
 type Props = {
   open: boolean;
   onClose: () => void;
-  session: SessionDetailResponse;
+  onSelectFamily: (id: number | null) => void;
+  registrationForm: ReactNode;
 };
 
-const RegistrationDialog = ({ open, onClose, session }: Props) => {
+const RegistrationDialog = ({
+  open,
+  onClose,
+  onSelectFamily,
+  registrationForm,
+}: Props) => {
   const classes = useStyles();
   const [shouldDisplaySearch, setShouldDisplaySearch] = useState(true);
   const [firstName, setFirstName] = useState("");
@@ -59,18 +59,13 @@ const RegistrationDialog = ({ open, onClose, session }: Props) => {
   const [shouldDisplayFamilyResults, setShouldDisplayFamilyResults] = useState(
     false
   );
-  const [
-    selectedFamily,
-    setSelectedFamily,
-  ] = useState<FamilyDetailResponse | null>(null);
 
   const resetDialog = () => {
     setFirstName("");
     setLastName("");
+    setShouldDisplaySearch(true);
     setShouldDisplayFamilyResults(false);
     setFamilyResults([]);
-    setSelectedFamily(null);
-    setShouldDisplaySearch(true);
   };
 
   useEffect(() => {
@@ -84,9 +79,9 @@ const RegistrationDialog = ({ open, onClose, session }: Props) => {
     );
   };
 
-  const onSelectFamily = async (id: number) => {
-    setSelectedFamily(await FamilyAPI.getFamilyById(id));
+  const handleSelectFamily = (id: number | null) => {
     setShouldDisplaySearch(false);
+    onSelectFamily(id);
   };
 
   return (
@@ -131,7 +126,7 @@ const RegistrationDialog = ({ open, onClose, session }: Props) => {
                 </Typography>
                 <FamilySearchResultsTable
                   families={familyResults}
-                  onSelectFamily={onSelectFamily}
+                  onSelectFamily={handleSelectFamily}
                 />
                 <Typography variant="h4" className={classes.dialogSubheading}>
                   Not found?
@@ -139,9 +134,7 @@ const RegistrationDialog = ({ open, onClose, session }: Props) => {
               </>
             )}
             <Box marginTop={2}>
-              <RoundedOutlinedButton
-                onClick={() => setShouldDisplaySearch(false)}
-              >
+              <RoundedOutlinedButton onClick={() => handleSelectFamily(null)}>
                 Register a new client
               </RoundedOutlinedButton>
             </Box>
@@ -152,11 +145,7 @@ const RegistrationDialog = ({ open, onClose, session }: Props) => {
               <NavigateBefore />
               Go back
             </Button>
-            <RegistrationForm
-              existingFamily={selectedFamily}
-              onSubmit={resetDialog}
-              session={session}
-            />
+            {registrationForm}
           </>
         )}
       </DialogContent>

--- a/src/components/registration/registration-form/RegistrationForm.unit.test.tsx
+++ b/src/components/registration/registration-form/RegistrationForm.unit.test.tsx
@@ -7,7 +7,7 @@ import userEvent from "@testing-library/user-event";
 import moment from "moment";
 
 import EnrolmentAPI from "api/EnrolmentAPI";
-import { SessionDetailResponse } from "api/types";
+import { EnrolmentFamilyResponse, SessionDetailResponse } from "api/types";
 import DefaultFields from "constants/DefaultFields";
 import EnrolmentStatus from "constants/EnrolmentStatus";
 import QuestionType from "constants/QuestionType";
@@ -34,7 +34,7 @@ describe("when the registration form is opened", () => {
       <MuiPickersUtilsProvider utils={MomentUtils}>
         <RegistrationForm
           existingFamily={null}
-          onSubmit={() => {}}
+          onRegister={() => {}}
           session={session}
         />
       </MuiPickersUtilsProvider>
@@ -151,7 +151,7 @@ describe("when text fields are submitted", () => {
         >
           <RegistrationForm
             existingFamily={null}
-            onSubmit={() => {}}
+            onRegister={() => {}}
             session={session}
           />
         </DynamicFieldsContext.Provider>
@@ -175,8 +175,8 @@ describe("when text fields are submitted", () => {
   it("structures the data in the required format", async () => {
     const session: SessionDetailResponse = {
       classes: [
-        { id: 1, name: "Class 1" },
-        { id: 2, name: "Class 2" },
+        { id: 1, name: "Class 1", colour: "FFFFFF" },
+        { id: 2, name: "Class 2", colour: "FFFFFF" },
       ],
       families: [],
       fields: [
@@ -190,7 +190,9 @@ describe("when text fields are submitted", () => {
       start_date: "2021-09-01",
     };
 
-    jest.spyOn(EnrolmentAPI, "postEnrolment").mockResolvedValue({});
+    jest
+      .spyOn(EnrolmentAPI, "postEnrolment")
+      .mockResolvedValue({} as EnrolmentFamilyResponse);
     const onSubmit = jest.fn(() => {});
     const { getByLabelText, getByRole, getByTestId } = render(
       <MuiPickersUtilsProvider utils={MomentUtils}>
@@ -204,7 +206,7 @@ describe("when text fields are submitted", () => {
         >
           <RegistrationForm
             existingFamily={null}
-            onSubmit={onSubmit}
+            onRegister={onSubmit}
             session={session}
           />
         </DynamicFieldsContext.Provider>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -56,6 +56,17 @@ const theme = createMuiTheme({
         wordBreak: "break-word",
       },
     },
+    MuiSnackbar: {
+      root: {
+        top: "80px !important",
+      },
+    },
+    MuiSnackbarContent: {
+      root: {
+        backgroundColor: "#ECE0FD",
+        color: defaultTheme.palette.text.primary,
+      },
+    },
     MuiTab: {
       root: {
         minWidth: 0,


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[add a confirmation toast when users register a client](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=1de642e0dc7049a7aa7bc6276ca3053e)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

1. refactored onSelectFamily and onSubmit logic in the registration dialog/form to be handled in Sessions instead
    - this lets us show the success message & refetch data without passing the event through so many layers
2. when users register a new family:
    - close the dialog
    - open the "all classes" tab (where the new family should now appear)
    - display a success toast 🍞 

<img width="1536" alt="Screen Shot 2021-08-08 at 10 52 46 AM" src="https://user-images.githubusercontent.com/37346399/128637222-462bd0f7-cedb-4129-8adc-46afed296f99.png">

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. register a new family
2. validate that everything in #2 above is happening

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- testing

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
