### PR TITLE
Display spinners when loading pages 💫 

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-firebaseui": "^4.1.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.2",
+    "react-spinners": "^0.11.0",
     "typescript": "^4.2.4",
     "web-vitals": "^1.0.1"
   },

--- a/src/components/common/spinner-overlay/SpinnerOverlay.tsx
+++ b/src/components/common/spinner-overlay/SpinnerOverlay.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+import { Backdrop } from "@material-ui/core";
+import { FadeLoader } from "react-spinners";
+
+import theme from "theme";
+
+import useStyles from "./styles";
+
+const SpinnerOverlay = () => {
+  const classes = useStyles();
+  return (
+    <Backdrop open className={classes.spinnerOverlay}>
+      <FadeLoader color={theme.palette.primary.main} />
+    </Backdrop>
+  );
+};
+
+export default SpinnerOverlay;

--- a/src/components/common/spinner-overlay/index.ts
+++ b/src/components/common/spinner-overlay/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SpinnerOverlay";

--- a/src/components/common/spinner-overlay/styles.ts
+++ b/src/components/common/spinner-overlay/styles.ts
@@ -1,0 +1,10 @@
+import { makeStyles } from "@material-ui/styles";
+
+const useStyles = makeStyles(() => ({
+  spinnerOverlay: {
+    backgroundColor: "#ffffffaa",
+    zIndex: 200,
+  },
+}));
+
+export default useStyles;

--- a/src/components/common/spinner/Spinner.tsx
+++ b/src/components/common/spinner/Spinner.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+import { Box } from "@material-ui/core";
+import { FadeLoader } from "react-spinners";
+
+import theme from "theme";
+
+import useStyles from "./styles";
+
+const Spinner = () => {
+  const classes = useStyles();
+  return (
+    <Box
+      position="sticky"
+      height={60}
+      width={60}
+      top="50%"
+      left="50%"
+      className={classes.spinner}
+    >
+      <FadeLoader color={theme.palette.primary.main} />
+    </Box>
+  );
+};
+
+export default Spinner;

--- a/src/components/common/spinner/index.ts
+++ b/src/components/common/spinner/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Spinner";

--- a/src/components/common/spinner/styles.ts
+++ b/src/components/common/spinner/styles.ts
@@ -1,0 +1,9 @@
+import { makeStyles } from "@material-ui/styles";
+
+const useStyles = makeStyles(() => ({
+  spinner: {
+    transform: "translate(-50%, -50%)",
+  },
+}));
+
+export default useStyles;

--- a/src/pages/MainRegistration.tsx
+++ b/src/pages/MainRegistration.tsx
@@ -9,6 +9,7 @@ import {
   FamilyDetailResponse,
   FamilyListResponse,
 } from "api/types";
+import SpinnerOverlay from "components/common/spinner-overlay";
 import FamilySidebar from "components/families/family-sidebar";
 import FamilyTable from "components/families/family-table";
 import DefaultFields from "constants/DefaultFields";
@@ -20,8 +21,13 @@ const MainRegistration = () => {
     selectedFamily,
     setSelectedFamily,
   ] = useState<FamilyDetailResponse | null>(null);
+  const [isLoadingFamilies, setIsLoadingFamilies] = useState(true);
 
-  const resetFamilies = async () => setFamilies(await FamilyAPI.getFamilies());
+  const resetFamilies = async () => {
+    setIsLoadingFamilies(true);
+    setFamilies(await FamilyAPI.getFamilies());
+    setIsLoadingFamilies(false);
+  };
 
   useEffect(() => {
     resetFamilies();
@@ -53,6 +59,7 @@ const MainRegistration = () => {
 
   return (
     <>
+      {isLoadingFamilies && <SpinnerOverlay />}
       <Typography variant="h1">Main registration</Typography>
       <FamilyTable
         families={families}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1164,6 +1164,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.13.10":
+  version "7.14.8"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.8.tgz#7119a56f421018852694290b9f9148097391b446"
+  integrity sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.6.0":
   version "7.14.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
@@ -1237,10 +1244,70 @@
   dependencies:
     "@date-io/core" "^1.3.13"
 
+"@emotion/cache@^11.4.0":
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.4.0.tgz#293fc9d9a7a38b9aad8e9337e5014366c3b09ac0"
+  integrity sha512-Zx70bjE7LErRO9OaZrhf22Qye1y4F7iDl+ITjet0J+i+B88PrAOBkKvaAWhxsZf72tDLajwCgfCjJ2dvH77C3g==
+  dependencies:
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/sheet" "^1.0.0"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    stylis "^4.0.3"
+
 "@emotion/hash@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
+
+"@emotion/memoize@^0.7.4":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
+  integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
+
+"@emotion/react@^11.1.4":
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.4.0.tgz#2465ad7b073a691409b88dfd96dc17097ddad9b7"
+  integrity sha512-4XklWsl9BdtatLoJpSjusXhpKv9YVteYKh9hPKP1Sxl+mswEFoUe0WtmtWjxEjkA51DQ2QRMCNOvKcSlCQ7ivg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@emotion/cache" "^11.4.0"
+    "@emotion/serialize" "^1.0.2"
+    "@emotion/sheet" "^1.0.1"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    hoist-non-react-statics "^3.3.1"
+
+"@emotion/serialize@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.2.tgz#77cb21a0571c9f68eb66087754a65fa97bfcd965"
+  integrity sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==
+  dependencies:
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/unitless" "^0.7.5"
+    "@emotion/utils" "^1.0.0"
+    csstype "^3.0.2"
+
+"@emotion/sheet@^1.0.0", "@emotion/sheet@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.0.1.tgz#245f54abb02dfd82326e28689f34c27aa9b2a698"
+  integrity sha512-GbIvVMe4U+Zc+929N1V7nW6YYJtidj31lidSmdYcWozwoBIObXBnaJkKNDjZrLm9Nc0BR+ZyHNaRZxqNZbof5g==
+
+"@emotion/unitless@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
+  integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
+
+"@emotion/utils@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.0.0.tgz#abe06a83160b10570816c913990245813a2fd6af"
+  integrity sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA==
+
+"@emotion/weak-memoize@^0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
+  integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
 "@eslint/eslintrc@^0.4.1":
   version "0.4.1"
@@ -6139,7 +6206,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -10124,6 +10191,13 @@ react-sortable-tree@^2.7.1:
     react-lifecycles-compat "^3.0.4"
     react-virtualized "^9.21.2"
 
+react-spinners@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/react-spinners/-/react-spinners-0.11.0.tgz#186fd150cc9f7ab1436227f70d5d113b47e9e43d"
+  integrity sha512-rDZc0ABWn/M1OryboGsWVmIPg8uYWl0L35jPUhr40+Yg+syVPjeHwvnB7XWaRpaKus3M0cG9BiJA+ZB0dAwWyw==
+  dependencies:
+    "@emotion/react" "^11.1.4"
+
 react-to-print@^2.8.0:
   version "2.12.4"
   resolved "https://registry.yarnpkg.com/react-to-print/-/react-to-print-2.12.4.tgz#d9ed1447719c321798896040b0945a5c73a8f0c1"
@@ -11400,6 +11474,11 @@ stylehacks@^4.0.0:
     browserslist "^4.0.0"
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
+
+stylis@^4.0.3:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.10.tgz#446512d1097197ab3f02fb3c258358c3f7a14240"
+  integrity sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg==
 
 supports-color@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[loading states](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=c313084dc5244d9a964f7f02ad79be41)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- added some spinny bois when waiting for api requests
- installed react-spinners to get this done - the material ui loaders have a limitation that gives the animation some hiccups ([docs](https://material-ui.com/components/progress/#limitations))

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. take the app for a spin
2. poke around the main registration, session, and class pages and make sure things feel okay

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- don't get dizzy

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
