### PR TITLE
Fix session fetching bug 🐛 

### DIFF
--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -75,22 +75,35 @@ const Sessions = () => {
     setIsLoadingSession(false);
   };
 
+  const goToLatestOrProvidedSession = () => {
+    if (!sessions.length) {
+      return;
+    }
+    if (!sessionId) {
+      history.push(`/sessions/${sessions[0].id}`);
+    } else {
+      updateSelectedSession(Number(sessionId));
+    }
+  };
+
   useEffect(() => {
     const fetchSessions = async () => {
       const sessionsData = await SessionAPI.getSessions();
       setSessions(sessionsData);
-      if (sessionId !== undefined) {
-        // if a session id was provided in the url, set it to that
-        updateSelectedSession(Number(sessionId));
-      } else if (sessionsData.length) {
-        // redirect to the most recent session
-        history.push(`/sessions/${sessionsData[0].id}`);
-        updateSelectedSession(sessionsData[0].id);
-      }
     };
     setIsLoadingSession(true);
-    fetchSessions();
-  }, []);
+    if (!sessions.length) {
+      fetchSessions();
+      return;
+    }
+    goToLatestOrProvidedSession();
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (sessions.length) {
+      goToLatestOrProvidedSession();
+    }
+  }, [sessions]);
 
   const handleOpenFormDialog = () => {
     setDisplayRegDialog(true);
@@ -99,13 +112,6 @@ const Sessions = () => {
   const handleCloseFormDialog = () => {
     setDisplayRegDialog(false);
   };
-
-  useEffect(() => {
-    setIsLoadingSession(true);
-    if (sessionId !== undefined) {
-      updateSelectedSession(Number(sessionId));
-    }
-  }, [sessionId]);
 
   const resetClass = async (id: number) => {
     setIsLoadingClass(true);


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[session fetching bug](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=3848f89ad53349e6899625ca4f216816)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- currently, if users click "Sessions" in the navbar when they're already on the sessions page, the page loads indefinitely
- this is happening because the sessions list data isn't re-fetched when they click it, so there's no "latest session" to navigate to!
- updated the useEffects to make sure sessions & the most latest session are refetched

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. go to the sessions page
2. click "sessions" again - the latest session should load again

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- testing

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
