### PR TITLE
Create a 404 page 🚫 

### DIFF
--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -70,8 +70,16 @@ const Sessions = () => {
   const [isLoadingClass, setIsLoadingClass] = useState(false);
   const [isLoadingFamily, setIsLoadingFamily] = useState(false);
 
+  const goTo404 = () => {
+    history.push("/oops");
+  };
+
   const updateSelectedSession = async (id: number) => {
-    setSelectedSession(await SessionAPI.getSession(id));
+    try {
+      setSelectedSession(await SessionAPI.getSession(id));
+    } catch (err) {
+      goTo404();
+    }
     setIsLoadingSession(false);
   };
 
@@ -109,7 +117,12 @@ const Sessions = () => {
 
   const resetClass = async (id: number) => {
     setIsLoadingClass(true);
-    const classObj = await ClassAPI.getClass(id);
+    let classObj: ClassDetailResponse;
+    try {
+      classObj = await ClassAPI.getClass(id);
+    } catch (err) {
+      goTo404();
+    }
     setClassesMap(
       (prevMap) => new Map([...Array.from(prevMap), [classObj.id, classObj]])
     );

--- a/src/pages/not-found/NotFound.tsx
+++ b/src/pages/not-found/NotFound.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+import { Button } from "@material-ui/core";
+import Box from "@material-ui/core/Box";
+import { ErrorOutline } from "@material-ui/icons";
+import { Link } from "react-router-dom";
+
+const NotFound = () => (
+  <Box
+    textAlign="center"
+    position="absolute"
+    top="50%"
+    left="50%"
+    style={{ transform: "translate(-50%, -50%)" }}
+  >
+    <Box>
+      <ErrorOutline fontSize="large" />
+    </Box>
+    <h1>Oh no! This page doesn&apos;t exist.</h1>
+    <Link to="/" style={{ textDecoration: "none" }}>
+      <Button color="primary">Return to all registrations</Button>
+    </Link>
+  </Box>
+);
+
+export default NotFound;

--- a/src/pages/not-found/NotFound.tsx
+++ b/src/pages/not-found/NotFound.tsx
@@ -5,22 +5,27 @@ import Box from "@material-ui/core/Box";
 import { ErrorOutline } from "@material-ui/icons";
 import { Link } from "react-router-dom";
 
-const NotFound = () => (
-  <Box
-    textAlign="center"
-    position="absolute"
-    top="50%"
-    left="50%"
-    style={{ transform: "translate(-50%, -50%)" }}
-  >
-    <Box>
-      <ErrorOutline fontSize="large" />
+import useStyles from "./styles";
+
+const NotFound = () => {
+  const classes = useStyles();
+  return (
+    <Box
+      textAlign="center"
+      position="absolute"
+      top="50%"
+      left="50%"
+      className={classes.container}
+    >
+      <Box>
+        <ErrorOutline fontSize="large" />
+      </Box>
+      <h1>Oh no! This page doesn&apos;t exist.</h1>
+      <Link to="/" style={{ textDecoration: "none" }}>
+        <Button color="primary">Return to all registrations</Button>
+      </Link>
     </Box>
-    <h1>Oh no! This page doesn&apos;t exist.</h1>
-    <Link to="/" style={{ textDecoration: "none" }}>
-      <Button color="primary">Return to all registrations</Button>
-    </Link>
-  </Box>
-);
+  );
+};
 
 export default NotFound;

--- a/src/pages/not-found/index.ts
+++ b/src/pages/not-found/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NotFound";

--- a/src/pages/not-found/styles.ts
+++ b/src/pages/not-found/styles.ts
@@ -1,0 +1,9 @@
+import { makeStyles } from "@material-ui/styles";
+
+const useStyles = makeStyles(() => ({
+  container: {
+    transform: "translate(-50%, -50%)",
+  },
+}));
+
+export default useStyles;

--- a/src/shared/ProjectREAD.jsx
+++ b/src/shared/ProjectREAD.jsx
@@ -9,6 +9,7 @@ import { DynamicFieldsProvider } from "context/DynamicFieldsContext";
 import { UsersProvider } from "context/UsersContext";
 import CreateSession from "pages/create-session";
 import MainRegistration from "pages/MainRegistration";
+import NotFound from "pages/not-found";
 import Sessions from "pages/Sessions";
 
 import Navbar from "./Navbar";
@@ -37,7 +38,8 @@ function ProjectREAD() {
                 ]}
                 component={Sessions}
               />
-              <Redirect to="/" />
+              <PrivateRoute exact path="/oops" component={NotFound} />
+              <Redirect to="/oops" />
             </Switch>
           </MuiPickersUtilsProvider>
         </Container>


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[404 pages](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=685ba659edb64e80ac1a4d20ad9a7800)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- build a 404 page at `/oops` that we route to if resources aren't found
<img width="1536" alt="Screen Shot 2021-08-12 at 8 33 43 PM" src="https://user-images.githubusercontent.com/37346399/129286810-9ac2f8d9-bc47-462b-a230-af7a17c2084f.png">

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. run the backend on uwblueprint/project-read-backend#109
1. go to a session/class URL that doesn't exist (ex. `/sessions/0` or `/sessions/{a real session id}/classes/0` and ensure you see the 404 page instead of an uncaught error

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- testing

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
