### PR TITLE
Disallow users from re-registering a family in a session

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,6 +28,7 @@
     ],
     "react/jsx-filename-extension": [1, { "extensions": [".jsx", ".tsx"] }],
     "react/jsx-props-no-spreading": [1, { "exceptions": ["Field"] }],
+    "react/require-default-props": [1, { "ignoreFunctionalComponents": true }],
     "no-use-before-define": "off",
     "import/order": [
       "error",

--- a/src/components/common/rounded-outlined-button/RoundedOutlinedButton.tsx
+++ b/src/components/common/rounded-outlined-button/RoundedOutlinedButton.tsx
@@ -13,13 +13,23 @@ const useStyles = makeStyles(() => ({
 
 type Props = {
   children: ReactNode;
-  onClick: () => void;
+  disabled?: boolean;
+  onClick?: () => void;
 };
 
-const RoundedOutlinedButton = ({ children, onClick }: Props) => {
+const RoundedOutlinedButton = ({
+  children,
+  disabled = false,
+  onClick = () => {},
+}: Props) => {
   const classes = useStyles();
   return (
-    <Button onClick={onClick} variant="outlined" className={classes.button}>
+    <Button
+      disabled={disabled}
+      onClick={onClick}
+      variant="outlined"
+      className={classes.button}
+    >
       {children}
     </Button>
   );

--- a/src/components/family-search/family-search-results-table/FamilySearchResultsTable.tsx
+++ b/src/components/family-search/family-search-results-table/FamilySearchResultsTable.tsx
@@ -10,10 +10,11 @@ import {
   TableCell,
   TableFooter,
   TableContainer,
+  Tooltip,
 } from "@material-ui/core";
 import { makeStyles } from "@material-ui/styles";
 
-import { FamilySearchResponse } from "api/types";
+import { FamilySearchResponse, SessionDetailResponse } from "api/types";
 import RoundedOutlinedButton from "components/common/rounded-outlined-button/RoundedOutlinedButton";
 import DefaultFields from "constants/DefaultFields";
 
@@ -33,10 +34,19 @@ const useStyles = makeStyles(() => ({
 type Props = {
   families: FamilySearchResponse[];
   onSelectFamily: (id: number) => void;
+  session: SessionDetailResponse;
 };
 
-const FamilySearchResultsTable = ({ families, onSelectFamily }: Props) => {
+const FamilySearchResultsTable = ({
+  families,
+  onSelectFamily,
+  session,
+}: Props) => {
   const classes = useStyles();
+
+  const isFamilyRegistered = (id: number): boolean =>
+    session.families.find((family) => family.id === id) !== undefined;
+
   return (
     <Box marginY={2}>
       <TableContainer
@@ -66,13 +76,26 @@ const FamilySearchResultsTable = ({ families, onSelectFamily }: Props) => {
                   <TableCell>{family.email}</TableCell>
                   <TableCell>{family.num_children}</TableCell>
                   <TableCell className={classes.selectButtonTableCell}>
-                    <RoundedOutlinedButton
-                      onClick={() => {
-                        onSelectFamily(family.id);
-                      }}
-                    >
-                      Select
-                    </RoundedOutlinedButton>
+                    {isFamilyRegistered(family.id) ? (
+                      <Tooltip
+                        title={`This family is already registered in ${session.name}`}
+                        aria-label="already registered"
+                      >
+                        <span>
+                          <RoundedOutlinedButton disabled>
+                            Select
+                          </RoundedOutlinedButton>
+                        </span>
+                      </Tooltip>
+                    ) : (
+                      <RoundedOutlinedButton
+                        onClick={() => {
+                          onSelectFamily(family.id);
+                        }}
+                      >
+                        Select
+                      </RoundedOutlinedButton>
+                    )}
                   </TableCell>
                 </TableRow>
               ))}

--- a/src/components/registration/RegistrationDialog.tsx
+++ b/src/components/registration/RegistrationDialog.tsx
@@ -13,7 +13,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import { Close, NavigateBefore } from "@material-ui/icons";
 
 import FamilyAPI from "api/FamilyAPI";
-import { FamilySearchResponse } from "api/types";
+import { FamilySearchResponse, SessionDetailResponse } from "api/types";
 import RoundedOutlinedButton from "components/common/rounded-outlined-button";
 import FamilySearchResultsTable from "components/family-search/family-search-results-table";
 import StudentSearchBar from "components/family-search/student-search-bar";
@@ -41,6 +41,7 @@ type Props = {
   onClose: () => void;
   onSelectFamily: (id: number | null) => void;
   registrationForm: ReactNode;
+  session: SessionDetailResponse;
 };
 
 const RegistrationDialog = ({
@@ -48,6 +49,7 @@ const RegistrationDialog = ({
   onClose,
   onSelectFamily,
   registrationForm,
+  session,
 }: Props) => {
   const classes = useStyles();
   const [shouldDisplaySearch, setShouldDisplaySearch] = useState(true);
@@ -127,6 +129,7 @@ const RegistrationDialog = ({
                 <FamilySearchResultsTable
                   families={familyResults}
                   onSelectFamily={handleSelectFamily}
+                  session={session}
                 />
                 <Typography variant="h4" className={classes.dialogSubheading}>
                   Not found?

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -370,6 +370,7 @@ const Sessions = () => {
                   />
                 )
               }
+              session={selectedSession}
             />
           </>
         )}


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[prevent families from being re-registered in the same session](https://www.notion.so/uwblueprintexecs/Sprint-3-481954865bf444498031befeafaad95a?p=741b918abd174e9d814a9e092368f445)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- adds a `disabled` prop to the RoundedOutlinedButton
- pass sessions data to the family search results table - if the family is already enrolled, show a disabled button with a tooltip explaining why they can't be selected
<img width="1007" alt="Screen Shot 2021-08-14 at 9 22 49 AM" src="https://user-images.githubusercontent.com/37346399/129447662-a871ffb6-2839-4c85-8f02-8ee71b8c18a1.png">

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. open the reg dialog and search for a family who's already enrolled in the session
2. validate that you can't select them!

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- happy saturday! 🌥️ 
- correctness & readability

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
