### PR TITLE
Update API requests called when registering new & existing families

### DIFF
--- a/src/api/EnrolmentAPI.ts
+++ b/src/api/EnrolmentAPI.ts
@@ -1,10 +1,5 @@
 import * as APIUtils from "./APIUtils";
-import {
-  EnrolmentFamilyRequest,
-  EnrolmentFamilyResponse,
-  EnrolmentRequest,
-  EnrolmentResponse,
-} from "./types";
+import { EnrolmentRequest, EnrolmentResponse } from "./types";
 
 export const enrolmentResponseToRequest = (
   data: EnrolmentResponse
@@ -16,9 +11,9 @@ export const enrolmentResponseToRequest = (
 });
 
 const postEnrolment = (
-  data: EnrolmentFamilyRequest
-): Promise<EnrolmentFamilyResponse> =>
-  APIUtils.post("/enrolments/", data) as Promise<EnrolmentFamilyResponse>;
+  data: Omit<EnrolmentRequest, "id">
+): Promise<EnrolmentResponse> =>
+  APIUtils.post("/enrolments/", data) as Promise<EnrolmentResponse>;
 
 const putEnrolment = (data: EnrolmentRequest): Promise<EnrolmentResponse> =>
   APIUtils.put(`/enrolments/${data.id}/`, data) as Promise<EnrolmentResponse>;

--- a/src/api/FamilyAPI.ts
+++ b/src/api/FamilyAPI.ts
@@ -20,6 +20,9 @@ const getFamiliesByParentName = (
 const getFamilyById = (id: number): Promise<FamilyDetailResponse> =>
   APIUtils.get(`/families/${id}`) as Promise<FamilyDetailResponse>;
 
+const postFamily = (data: FamilyRequest): Promise<FamilyDetailResponse> =>
+  APIUtils.post(`/families/`, data) as Promise<FamilyDetailResponse>;
+
 const putFamily = (
   data: FamilyRequest & { id: number }
 ): Promise<FamilyDetailResponse> =>
@@ -29,5 +32,6 @@ export default {
   getFamilies,
   getFamiliesByParentName,
   getFamilyById,
+  postFamily,
   putFamily,
 };

--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -28,16 +28,13 @@ export type SessionDetailResponse = Session & {
   families: FamilyListResponse[];
 };
 
-export type EnrolmentResponse = Pick<
-  Enrolment,
-  "id" | "status" | "students"
-> & {
+export type EnrolmentResponse = Enrolment & {
   session: SessionListResponse;
   preferred_class: ClassListResponse | null;
   enrolled_class: ClassListResponse | null;
 };
 
-export type EnrolmentRequest = Pick<Enrolment, "id" | "status" | "students"> & {
+export type EnrolmentRequest = Enrolment & {
   session: number;
   preferred_class: number | null;
   enrolled_class: number | null;
@@ -112,18 +109,6 @@ export type FamilyRequest = FamilyBaseRequest & {
   guests: StudentRequest[];
   parent: StudentRequest;
   interactions: Interaction[];
-};
-
-export type EnrolmentFamilyRequest = Pick<Enrolment, "status"> & {
-  family: FamilyRequest;
-  session: number;
-  preferred_class: number | null;
-};
-
-export type EnrolmentFamilyResponse = Pick<Enrolment, "status"> & {
-  family: FamilyDetailResponse;
-  session: number;
-  preferred_class: number | null;
 };
 
 export type DynamicFieldsResponse = {

--- a/src/components/families/family-form/types.ts
+++ b/src/components/families/family-form/types.ts
@@ -1,8 +1,4 @@
-import {
-  EnrolmentFamilyRequest,
-  FamilyBaseRequest,
-  StudentRequest,
-} from "api/types";
+import { FamilyBaseRequest, StudentRequest } from "api/types";
 import { Interaction } from "types";
 
 export type InteractionFormData = Interaction & {
@@ -17,11 +13,4 @@ export type FamilyFormData = FamilyBaseRequest & {
   guests: StudentFormData[];
   parent: StudentRequest;
   interactions: InteractionFormData[];
-};
-
-export type EnrolmentFormData = Pick<
-  EnrolmentFamilyRequest,
-  "preferred_class" | "session" | "status"
-> & {
-  family: FamilyFormData;
 };

--- a/src/components/registration/registration-form/RegistrationForm.tsx
+++ b/src/components/registration/registration-form/RegistrationForm.tsx
@@ -140,6 +140,7 @@ const RegistrationForm = ({ existingFamily, onRegister, session }: Props) => {
         ...enrolment,
         family: familyResponse.id,
         enrolled_class: null,
+        // TODO: select students who are attending the session
         students: [familyResponse.parent.id],
       });
       onRegister(familyResponse);

--- a/src/components/registration/registration-form/RegistrationForm.tsx
+++ b/src/components/registration/registration-form/RegistrationForm.tsx
@@ -12,20 +12,18 @@ import { grey } from "@material-ui/core/colors";
 import { makeStyles } from "@material-ui/styles";
 
 import EnrolmentAPI from "api/EnrolmentAPI";
+import FamilyAPI from "api/FamilyAPI";
 import {
   StudentRequest,
   SessionDetailResponse,
-  EnrolmentFamilyResponse,
   FamilyDetailResponse,
+  EnrolmentRequest,
 } from "api/types";
 import FormRow from "components/common/form-row";
 import FamilyParentFields from "components/families/family-form/family-parent-fields";
 import StudentDynamicFields from "components/families/family-form/student-dynamic-fields";
 import StudentForm from "components/families/family-form/student-form";
-import {
-  EnrolmentFormData,
-  FamilyFormData,
-} from "components/families/family-form/types";
+import { FamilyFormData } from "components/families/family-form/types";
 import {
   familyFormDataToFamilyRequest,
   familyResponseToFamilyFormData,
@@ -83,13 +81,15 @@ const defaultFamilyData: FamilyFormData = {
 };
 
 export const defaultEnrolmentData = {
+  enrolled_class: null,
   preferred_class: null,
   status: EnrolmentStatus.REGISTERED,
+  students: [],
 };
 
 type Props = {
   existingFamily: FamilyDetailResponse | null;
-  onRegister: (enrolment: EnrolmentFamilyResponse) => void;
+  onRegister: (family: FamilyDetailResponse) => void;
   session: SessionDetailResponse;
 };
 
@@ -102,21 +102,24 @@ const RegistrationForm = ({ existingFamily, onRegister, session }: Props) => {
     sessionDynamicFields,
   } = useContext(DynamicFieldsContext);
 
-  const [enrolment, setEnrolment] = useState<EnrolmentFormData>({
-    family: { ...defaultFamilyData },
+  const [family, setFamily] = useState<FamilyFormData>(
+    existingFamily !== null
+      ? familyResponseToFamilyFormData(existingFamily)
+      : defaultFamilyData
+  );
+  const [enrolment, setEnrolment] = useState<
+    Omit<EnrolmentRequest, "family" | "id">
+  >({
     session: session.id,
     ...defaultEnrolmentData,
   });
 
   useEffect(() => {
-    setEnrolment({
-      family:
-        existingFamily !== null
-          ? familyResponseToFamilyFormData(existingFamily)
-          : defaultFamilyData,
-      session: session.id,
-      ...defaultEnrolmentData,
-    });
+    setFamily(
+      existingFamily !== null
+        ? familyResponseToFamilyFormData(existingFamily)
+        : defaultFamilyData
+    );
   }, [existingFamily]);
 
   const getSessionDynamicFields = (dynamicFields: DynamicField[]) =>
@@ -126,20 +129,24 @@ const RegistrationForm = ({ existingFamily, onRegister, session }: Props) => {
 
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (existingFamily === null) {
-      try {
-        onRegister(
-          await EnrolmentAPI.postEnrolment({
-            ...enrolment,
-            family: familyFormDataToFamilyRequest(enrolment.family),
+    try {
+      const familyResponse = existingFamily
+        ? await FamilyAPI.putFamily({
+            ...familyFormDataToFamilyRequest(family),
+            id: existingFamily.id,
           })
-        );
-      } catch (err) {
-        // eslint-disable-next-line no-alert
-        alert(err);
-      }
+        : await FamilyAPI.postFamily(familyFormDataToFamilyRequest(family));
+      await EnrolmentAPI.postEnrolment({
+        ...enrolment,
+        family: familyResponse.id,
+        enrolled_class: null,
+        students: [familyResponse.parent.id],
+      });
+      onRegister(familyResponse);
+    } catch (err) {
+      // eslint-disable-next-line no-alert
+      alert(err);
     }
-    // TODO: if there was an existing family, make a PUT request and call onRegister
   };
 
   return (
@@ -174,11 +181,11 @@ const RegistrationForm = ({ existingFamily, onRegister, session }: Props) => {
           dense={false}
           dynamicFields={getSessionDynamicFields(parentDynamicFields)}
           isEditing
-          family={enrolment.family}
+          family={family}
           onChange={(value) =>
-            setEnrolment({
-              ...enrolment,
-              family: { ...enrolment.family, ...value },
+            setFamily({
+              ...family,
+              ...value,
             })
           }
         />
@@ -190,26 +197,26 @@ const RegistrationForm = ({ existingFamily, onRegister, session }: Props) => {
           dynamicFields={getSessionDynamicFields(childDynamicFields)}
           isEditing
           onChange={(children) =>
-            setEnrolment({
-              ...enrolment,
-              family: { ...enrolment.family, children },
+            setFamily({
+              ...family,
+              children,
             })
           }
           role={StudentRole.CHILD}
-          students={enrolment.family.children}
+          students={family.children}
         />
         <StudentForm
           dense={false}
           dynamicFields={getSessionDynamicFields(guestDynamicFields)}
           isEditing
           onChange={(guests) =>
-            setEnrolment({
-              ...enrolment,
-              family: { ...enrolment.family, guests },
+            setFamily({
+              ...family,
+              guests,
             })
           }
           role={StudentRole.GUEST}
-          students={enrolment.family.guests}
+          students={family.guests}
         />
       </Box>
 
@@ -250,15 +257,12 @@ const RegistrationForm = ({ existingFamily, onRegister, session }: Props) => {
         <StudentDynamicFields
           dense={false}
           dynamicFields={getSessionDynamicFields(sessionDynamicFields)}
-          information={enrolment.family.parent.information}
+          information={family.parent.information}
           isEditing
           onChange={(value) =>
-            setEnrolment({
-              ...enrolment,
-              family: {
-                ...enrolment.family,
-                parent: { ...enrolment.family.parent, information: value },
-              },
+            setFamily({
+              ...family,
+              parent: { ...family.parent, information: value },
             })
           }
           variant={FieldVariant.STACKED}
@@ -312,12 +316,12 @@ const RegistrationForm = ({ existingFamily, onRegister, session }: Props) => {
             inputProps={{ "data-testid": TestId.NotesInput }}
             multiline
             onChange={(e) =>
-              setEnrolment({
-                ...enrolment,
-                family: { ...enrolment.family, notes: e.target.value },
+              setFamily({
+                ...family,
+                notes: e.target.value,
               })
             }
-            value={enrolment.family.notes}
+            value={family.notes}
           />
         </FormRow>
       </Box>

--- a/src/components/registration/registration-form/RegistrationForm.tsx
+++ b/src/components/registration/registration-form/RegistrationForm.tsx
@@ -141,7 +141,11 @@ const RegistrationForm = ({ existingFamily, onRegister, session }: Props) => {
         family: familyResponse.id,
         enrolled_class: null,
         // TODO: select students who are attending the session
-        students: [familyResponse.parent.id],
+        students: [
+          familyResponse.parent.id,
+          ...familyResponse.children.map((child) => child.id),
+          ...familyResponse.guests.map((guest) => guest.id),
+        ],
       });
       onRegister(familyResponse);
     } catch (err) {

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -358,11 +358,11 @@ const Sessions = () => {
                 ) : (
                   <RegistrationForm
                     existingFamily={selectedFamily}
-                    onRegister={(enrolment) => {
+                    onRegister={(family) => {
                       setDisplayRegDialog(false);
                       setClassTabIndex(ALL_CLASSES_TAB_INDEX);
                       setSnackbarMessage(
-                        `Successfully added ${enrolment.family.parent.first_name} ${enrolment.family.parent.last_name} to this session.`
+                        `Successfully added ${family.parent.first_name} ${family.parent.last_name} to this session.`
                       );
                       updateSelectedSession(selectedSession.id);
                     }}

--- a/src/tests/registration/Registration.int.test.tsx
+++ b/src/tests/registration/Registration.int.test.tsx
@@ -32,12 +32,13 @@ import {
 
 describe("RegistrationForm", () => {
   it("creates a family and enrolment when registering a new family", async () => {
-    jest.setTimeout(10000);
     jest.spyOn(FamilyAPI, "postFamily").mockResolvedValue({
       id: 1,
       parent: {
         id: 2,
       },
+      children: [{ id: 3 }],
+      guests: [{ id: 4 }],
     } as FamilyDetailResponse);
     jest
       .spyOn(EnrolmentAPI, "postEnrolment")
@@ -270,9 +271,9 @@ describe("RegistrationForm", () => {
       preferred_class: session.classes[1].id,
       session: session.id,
       status: EnrolmentStatus.SIGNED_UP,
-      students: [2],
+      students: [2, 3, 4],
     });
 
     expect(onRegister).toHaveBeenCalledTimes(1);
-  });
+  }, 15000);
 });

--- a/src/tests/registration/Registration.int.test.tsx
+++ b/src/tests/registration/Registration.int.test.tsx
@@ -32,6 +32,7 @@ import {
 
 describe("RegistrationForm", () => {
   it("creates a family and enrolment when registering a new family", async () => {
+    jest.setTimeout(10000);
     jest.spyOn(FamilyAPI, "postFamily").mockResolvedValue({
       id: 1,
       parent: {

--- a/src/tests/registration/Registration.int.test.tsx
+++ b/src/tests/registration/Registration.int.test.tsx
@@ -7,6 +7,7 @@ import userEvent from "@testing-library/user-event";
 import moment from "moment";
 
 import EnrolmentAPI from "api/EnrolmentAPI";
+import FamilyAPI from "api/FamilyAPI";
 import {
   EnrolmentResponse,
   FamilyDetailResponse,
@@ -28,7 +29,6 @@ import {
   TEST_PARENT_DYNAMIC_FIELD,
   TEST_SESSION_DYNAMIC_FIELD,
 } from "./constants";
-import FamilyAPI from "api/FamilyAPI";
 
 describe("RegistrationForm", () => {
   it("creates a family and enrolment when registering a new family", async () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -78,6 +78,7 @@ export type Class = {
 
 export type Enrolment = {
   id: number;
+  family: number; // family id
   status: EnrolmentStatus;
   students: number[];
 };


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Update family & create enrolment when registering an existing family](https://www.notion.so/uwblueprintexecs/Sprint-3-481954865bf444498031befeafaad95a?p=f71a3bc2a5d34afc8f0e03c44962b70c)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- updates the API requests called when registering a new family, changed in uwblueprint/project-read-backend#110
  - waits for POST /families to be called first, then POST /enrolments
- if the family already existed, call PUT /families

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. yarn test
2. try registering an existing family & editing their data!

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- correctness!!! this is big that we get it right

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
