### PR TITLE
Display confirmation dialogs when users try to leave the registration dialog

### DIFF
--- a/src/components/common/confirmation-dialog/ConfirmationDialog.tsx
+++ b/src/components/common/confirmation-dialog/ConfirmationDialog.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from "@material-ui/core";
+
+import useStyles from "./styles";
+
+const BASE_NAME = "confirmation-dialog";
+
+type Props = {
+  description: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+  open: boolean;
+  title: string;
+};
+
+const ConfirmationDialog = ({
+  description,
+  onCancel,
+  onConfirm,
+  open,
+  title,
+}: Props) => {
+  const classes = useStyles();
+  return (
+    <Dialog
+      open={open}
+      onClose={onCancel}
+      aria-labelledby={`${BASE_NAME}-title`}
+      aria-describedby={`${BASE_NAME}-description`}
+      PaperProps={{ className: classes.dialog }}
+    >
+      <DialogTitle id={`${BASE_NAME}-title`} className={classes.title}>
+        {title}
+      </DialogTitle>
+      <DialogContent className={classes.content}>
+        <DialogContentText id={`${BASE_NAME}-description`}>
+          {description}
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onConfirm} color="default" variant="contained">
+          Leave this page
+        </Button>
+        <Button
+          onClick={onCancel}
+          color="primary"
+          variant="contained"
+          autoFocus
+        >
+          Stay on this page
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ConfirmationDialog;

--- a/src/components/common/confirmation-dialog/index.ts
+++ b/src/components/common/confirmation-dialog/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ConfirmationDialog";

--- a/src/components/common/confirmation-dialog/styles.ts
+++ b/src/components/common/confirmation-dialog/styles.ts
@@ -1,0 +1,15 @@
+import { makeStyles } from "@material-ui/styles";
+
+const useStyles = makeStyles(() => ({
+  dialog: {
+    padding: 16,
+  },
+  content: {
+    padding: 8,
+  },
+  title: {
+    padding: 8,
+  },
+}));
+
+export default useStyles;

--- a/src/components/registration/RegistrationDialog.tsx
+++ b/src/components/registration/RegistrationDialog.tsx
@@ -89,7 +89,6 @@ const RegistrationDialog = ({
 
   const handleSelectFamily = (id: number | null) => {
     setShouldDisplaySearch(false);
-    window.onbeforeunload = () => true;
     onSelectFamily(id);
   };
 

--- a/src/components/registration/RegistrationDialog.tsx
+++ b/src/components/registration/RegistrationDialog.tsx
@@ -2,7 +2,6 @@ import React, { ReactNode, useEffect, useState } from "react";
 
 import {
   Box,
-  Button,
   Dialog,
   DialogContent,
   DialogTitle,
@@ -10,10 +9,11 @@ import {
   Typography,
 } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
-import { Close, NavigateBefore } from "@material-ui/icons";
+import { Close } from "@material-ui/icons";
 
 import FamilyAPI from "api/FamilyAPI";
 import { FamilySearchResponse, SessionDetailResponse } from "api/types";
+import ConfirmationDialog from "components/common/confirmation-dialog";
 import RoundedOutlinedButton from "components/common/rounded-outlined-button";
 import FamilySearchResultsTable from "components/family-search/family-search-results-table";
 import StudentSearchBar from "components/family-search/student-search-bar";
@@ -61,6 +61,7 @@ const RegistrationDialog = ({
   const [shouldDisplayFamilyResults, setShouldDisplayFamilyResults] = useState(
     false
   );
+  const [isConfirming, setIsConfirming] = useState(false);
 
   const resetDialog = () => {
     setFirstName("");
@@ -71,7 +72,12 @@ const RegistrationDialog = ({
   };
 
   useEffect(() => {
-    resetDialog();
+    if (open) {
+      window.onbeforeunload = () => true;
+      resetDialog();
+    } else {
+      window.onbeforeunload = null;
+    }
   }, [open]);
 
   const onSubmitSearch = async () => {
@@ -83,76 +89,89 @@ const RegistrationDialog = ({
 
   const handleSelectFamily = (id: number | null) => {
     setShouldDisplaySearch(false);
+    window.onbeforeunload = () => true;
     onSelectFamily(id);
   };
 
+  const handleClose = () => {
+    setIsConfirming(true);
+  };
+
   return (
-    <Dialog
-      open={open}
-      onClose={onClose}
-      disableBackdropClick
-      fullWidth
-      maxWidth="md"
-      classes={{ paper: classes.dialogPaper }}
-    >
-      <DialogTitle disableTypography>
-        <Typography variant="h2">Add a client</Typography>
-        <IconButton
-          aria-label="close"
-          onClick={onClose}
-          className={classes.closeButton}
-        >
-          <Close />
-        </IconButton>
-      </DialogTitle>
-      <DialogContent>
-        {shouldDisplaySearch ? (
-          <>
-            <Typography variant="h3" className={classes.dialogHeading}>
-              Search for a client
-            </Typography>
-            <Typography variant="body1">
-              Make sure the client being registered isn’t already enrolled.
-            </Typography>
-            <StudentSearchBar
-              firstName={firstName}
-              lastName={lastName}
-              onChangeFirstName={setFirstName}
-              onChangeLastName={setLastName}
-              onSubmit={onSubmitSearch}
-            />
-            {shouldDisplayFamilyResults && (
-              <>
-                <Typography variant="h4" className={classes.dialogSubheading}>
-                  Search results
-                </Typography>
-                <FamilySearchResultsTable
-                  families={familyResults}
-                  onSelectFamily={handleSelectFamily}
-                  session={session}
-                />
-                <Typography variant="h4" className={classes.dialogSubheading}>
-                  Not found?
-                </Typography>
-              </>
-            )}
-            <Box marginTop={2}>
-              <RoundedOutlinedButton onClick={() => handleSelectFamily(null)}>
-                Register a new client
-              </RoundedOutlinedButton>
-            </Box>
-          </>
-        ) : (
-          <>
-            <Button onClick={resetDialog}>
-              <NavigateBefore />
-              Go back
-            </Button>
-            {registrationForm}
-          </>
-        )}
-      </DialogContent>
-    </Dialog>
+    <>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        disableBackdropClick
+        fullWidth
+        maxWidth="md"
+        classes={{ paper: classes.dialogPaper }}
+      >
+        <DialogTitle disableTypography>
+          <Typography variant="h2">Add a client</Typography>
+          <IconButton
+            aria-label="close"
+            onClick={handleClose}
+            className={classes.closeButton}
+          >
+            <Close />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent>
+          {shouldDisplaySearch ? (
+            <>
+              <Typography variant="h3" className={classes.dialogHeading}>
+                Search for a client
+              </Typography>
+              <Typography variant="body1">
+                Make sure the client being registered isn’t already enrolled.
+              </Typography>
+              <StudentSearchBar
+                firstName={firstName}
+                lastName={lastName}
+                onChangeFirstName={setFirstName}
+                onChangeLastName={setLastName}
+                onSubmit={onSubmitSearch}
+              />
+              {shouldDisplayFamilyResults && (
+                <>
+                  <Typography variant="h4" className={classes.dialogSubheading}>
+                    Search results
+                  </Typography>
+                  <FamilySearchResultsTable
+                    families={familyResults}
+                    onSelectFamily={handleSelectFamily}
+                    session={session}
+                  />
+                  <Typography variant="h4" className={classes.dialogSubheading}>
+                    Not found?
+                  </Typography>
+                </>
+              )}
+              <Box marginTop={2}>
+                <RoundedOutlinedButton onClick={() => handleSelectFamily(null)}>
+                  Register a new client
+                </RoundedOutlinedButton>
+              </Box>
+            </>
+          ) : (
+            <>{registrationForm}</>
+          )}
+        </DialogContent>
+      </Dialog>
+      <ConfirmationDialog
+        description="This information will not be saved."
+        onCancel={() => {
+          setIsConfirming(false);
+        }}
+        onConfirm={() => {
+          setIsConfirming(false);
+          onClose();
+        }}
+        open={isConfirming}
+        title="Are you sure you want to go back to Sessions?"
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Add a confirmation modal when users leave the page while registering](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=2c2303222dc04fc6b7e497ab2205efe6)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- added a ConfirmationDialog component that's displayed when users try to close the registration dialog
- removed the "go back" button for now (implementation a lil more complex, and in a rush to get this in!)

when users click the close button or esc key:
<img width="1536" alt="Screen Shot 2021-08-15 at 12 05 54 PM" src="https://user-images.githubusercontent.com/37346399/129484841-449fbfd1-3012-4f37-ba25-849ef92b1ab6.png">

when users try to click the browser's back button, or close the tab/window:
<img width="1536" alt="Screen Shot 2021-08-15 at 12 07 37 PM" src="https://user-images.githubusercontent.com/37346399/129484895-8debd5eb-9c39-4b0d-aa08-af900edcca93.png">

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Testing
- open the registration dialog/form and verify you can't close it without a confirmation dialog
- clicking confirm should proceed with whatever action was performed, whereas cancel should keep the form intact
- the dialog shouldn't appear anywhere when doing things outside the registration dialog

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- testing

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
