### PR TITLE
Add a class date to the attendance sheet

### DIFF
--- a/src/components/sessions/session-detail-view/AttendanceTable.tsx
+++ b/src/components/sessions/session-detail-view/AttendanceTable.tsx
@@ -5,6 +5,7 @@ import {
   Checkbox,
   createMuiTheme,
   MuiThemeProvider,
+  Tooltip,
 } from "@material-ui/core";
 import IconButton from "@material-ui/core/IconButton";
 import AddIcon from "@material-ui/icons/Add";
@@ -122,9 +123,11 @@ const AttendanceTable = ({
         </Button>
         {isEditing ? (
           <>
-            <IconButton onClick={() => setOpen(true)}>
-              <AddIcon />
-            </IconButton>
+            <Tooltip title="Add Date">
+              <IconButton onClick={() => setOpen(true)}>
+                <AddIcon />
+              </IconButton>
+            </Tooltip>
             <KeyboardDatePicker
               disableToolbar
               open={open}

--- a/src/components/sessions/session-detail-view/AttendanceTable.tsx
+++ b/src/components/sessions/session-detail-view/AttendanceTable.tsx
@@ -6,7 +6,10 @@ import {
   createMuiTheme,
   MuiThemeProvider,
 } from "@material-ui/core";
+import IconButton from "@material-ui/core/IconButton";
+import AddIcon from "@material-ui/icons/Add";
 import CheckIcon from "@material-ui/icons/Check";
+import { KeyboardDatePicker } from "@material-ui/pickers";
 import { makeStyles } from "@material-ui/styles";
 import _ from "lodash";
 import moment from "moment";
@@ -17,6 +20,7 @@ import MUIDataTable, {
 
 import { ClassDetailResponse, ClassRequest } from "api/types";
 import DefaultFieldKey from "constants/DefaultFieldKey";
+import { Attendance } from "types/index";
 
 type AttendanceTableRow = {
   id: string;
@@ -52,6 +56,7 @@ const AttendanceTable = ({
   onSubmit,
 }: AttendanceTableProps) => {
   const classes = useStyles();
+  const [open, setOpen] = useState(false);
   const [data, setData] = useState<ClassRequest>(_.cloneDeep(classObj));
   const [tableRows, setTableRows] = useState<AttendanceTableRow[]>([]);
 
@@ -69,6 +74,21 @@ const AttendanceTable = ({
       newData.attendance[dateIndex].attendees.splice(idIndex, 1);
     }
     setData(newData);
+  };
+
+  const addDate = (date: string) => {
+    const dateIndex = data.attendance.findIndex(
+      (element: { date: string }) => element.date === date
+    );
+    if (dateIndex === -1) {
+      const newData: ClassDetailResponse = _.cloneDeep(data);
+      const newDate: Attendance = {
+        date,
+        attendees: [],
+      };
+      newData.attendance.push(newDate);
+      setData(newData);
+    }
   };
 
   const getMuiTheme = () =>
@@ -90,15 +110,35 @@ const AttendanceTable = ({
     selectableRows: "none",
     elevation: 0,
     customToolbar: () => (
-      <Button
-        variant="outlined"
-        color={!isEditing ? "default" : "primary"}
-        onClick={() => onSubmit(data)}
-        className={classes.button}
-      >
-        {!isEditing ? "Take attendance " : "Done attendance "}
-        <CheckIcon className={classes.checkmark} />
-      </Button>
+      <>
+        <Button
+          variant="outlined"
+          color={!isEditing ? "default" : "primary"}
+          onClick={() => onSubmit(data)}
+          className={classes.button}
+        >
+          {!isEditing ? "Take attendance " : "Done attendance "}
+          <CheckIcon className={classes.checkmark} />
+        </Button>
+        {isEditing ? (
+          <>
+            <IconButton onClick={() => setOpen(true)}>
+              <AddIcon />
+            </IconButton>
+            <KeyboardDatePicker
+              disableToolbar
+              open={open}
+              onOpen={() => setOpen(true)}
+              onClose={() => setOpen(false)}
+              onChange={(date) =>
+                date ? addDate(date.toDate().toISOString().split("T")[0]) : null
+              }
+              TextFieldComponent={() => null}
+              value={null}
+            />
+          </>
+        ) : null}
+      </>
     ),
   };
 


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Add a class date to the attendance sheet](https://www.notion.so/uwblueprintexecs/Add-a-class-date-to-the-attendance-sheet-8ca16ef5d83543c2adce0b976407b70f)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- Display add attendance date button when "Take Attendance" is clicked
- Display date picker when add attendance date button is clicked
- Add the new date column to attendance table when OK is clicked
- If "Done Attendance" is clicked, the new date column should be saved
- If "Done Attendance" is not clicked, don't save the new column

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Go to attendance table and click Take Attendance
2. Click the plus button and add dates and verify columns show up! (if Done Attendance is not clicked, make sure the column isn't saved)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- correctness

### Checklist

- [X] My PR name is descriptive and in imperative tense
- [X] I have run the linter
- [X] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
