### PR TITLE
Display multiple current enrolments in the sidebar

### DIFF
--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -64,7 +64,6 @@ export type FamilyDetailResponse = Pick<
   | "interactions"
 > & {
   children: Student[];
-  current_enrolment: EnrolmentResponse | null;
   enrolments: EnrolmentResponse[];
   guests: Student[];
 };

--- a/src/components/families/family-sidebar/FamilySidebar.tsx
+++ b/src/components/families/family-sidebar/FamilySidebar.tsx
@@ -244,7 +244,7 @@ const FamilySidebar = ({
         </Typography>
 
         <Typography variant="h3" className={classes.heading}>
-          Enrolments
+          Enrolment
         </Typography>
         {activeEnrolments.length ? (
           activeEnrolments.map((enrolment, i) => (

--- a/src/components/families/family-sidebar/FamilySidebar.tsx
+++ b/src/components/families/family-sidebar/FamilySidebar.tsx
@@ -91,7 +91,7 @@ const useStyles = makeStyles((theme) => ({
 type Props = {
   family: FamilyDetailResponse;
   isOpen: boolean;
-  onEditCurrentEnrolment: (enrolment: EnrolmentRequest) => void;
+  onEditEnrolment: (enrolment: EnrolmentRequest) => void;
   onSaveFamily: (family: FamilyDetailResponse, refetch: boolean) => void;
   onClose: () => void;
 };
@@ -100,7 +100,7 @@ const FamilySidebar = ({
   family,
   isOpen,
   onClose,
-  onEditCurrentEnrolment,
+  onEditEnrolment,
   onSaveFamily,
 }: Props) => {
   const { currentUser, users } = useContext(UsersContext);
@@ -159,7 +159,13 @@ const FamilySidebar = ({
     return true;
   };
 
-  // Family form =============================================================
+  // Enrolments ===============================================================
+
+  const activeEnrolments = family.enrolments.filter(
+    (enrolment) => enrolment.session.active
+  );
+
+  // Family form ==============================================================
 
   const resetFormData = () => {
     setFamilyFormData(familyResponseToFamilyFormData(family));
@@ -238,12 +244,22 @@ const FamilySidebar = ({
         </Typography>
 
         <Typography variant="h3" className={classes.heading}>
-          Enrolment
+          Enrolments
         </Typography>
-        <EnrolmentForm
-          enrolment={family.current_enrolment}
-          onChange={onEditCurrentEnrolment}
-        />
+        {activeEnrolments.length ? (
+          activeEnrolments.map((enrolment, i) => (
+            <div key={enrolment.id}>
+              <EnrolmentForm enrolment={enrolment} onChange={onEditEnrolment} />
+              {i < activeEnrolments.length - 1 && (
+                <Box paddingY={2}>
+                  <Divider />
+                </Box>
+              )}
+            </div>
+          ))
+        ) : (
+          <EnrolmentForm enrolment={null} />
+        )}
 
         <Box paddingTop={2}>
           <Divider />

--- a/src/components/families/family-sidebar/FamilySidebar.tsx
+++ b/src/components/families/family-sidebar/FamilySidebar.tsx
@@ -165,6 +165,10 @@ const FamilySidebar = ({
     (enrolment) => enrolment.session.active
   );
 
+  const previousEnrolments = family.enrolments.filter(
+    (enrolment) => !enrolment.session.active
+  );
+
   // Family form ==============================================================
 
   const resetFormData = () => {
@@ -383,9 +387,8 @@ const FamilySidebar = ({
         <Typography variant="h3" className={classes.heading}>
           Previous Enrolments
         </Typography>
-        {family.enrolments
-          .filter((enrolment) => !enrolment.session.active)
-          .map((enrolment) => (
+        {previousEnrolments.length ? (
+          previousEnrolments.map((enrolment) => (
             <PreviousEnrolmentCard
               key={enrolment.id}
               enrolment={enrolment}
@@ -393,7 +396,12 @@ const FamilySidebar = ({
                 .concat(family.parent)
                 .concat(family.guests)}
             />
-          ))}
+          ))
+        ) : (
+          <Box paddingLeft={2}>
+            <Typography variant="body2">No previous enrolments</Typography>
+          </Box>
+        )}
       </Box>
 
       {isEditingFamily && (

--- a/src/components/families/family-sidebar/enrolment-form/EnrolmentForm.tsx
+++ b/src/components/families/family-sidebar/enrolment-form/EnrolmentForm.tsx
@@ -48,10 +48,10 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 type Props = {
   enrolment: EnrolmentResponse | null;
-  onChange: (enrolment: EnrolmentRequest) => void;
+  onChange?: (enrolment: EnrolmentRequest) => void;
 };
 
-const EnrolmentForm = ({ enrolment, onChange }: Props) => {
+const EnrolmentForm = ({ enrolment, onChange = () => {} }: Props) => {
   const classes = useStyles();
 
   const SessionRow = () => (

--- a/src/components/families/family-sidebar/utils.ts
+++ b/src/components/families/family-sidebar/utils.ts
@@ -1,0 +1,14 @@
+import EnrolmentAPI from "api/EnrolmentAPI";
+import { EnrolmentRequest, EnrolmentResponse } from "api/types";
+
+const saveEnrolments = async (
+  enrolments: EnrolmentResponse[],
+  data: EnrolmentRequest
+) => {
+  const enrolmentsData = [...enrolments];
+  const index = enrolments.findIndex((enrolment) => enrolment.id === data.id);
+  enrolmentsData[index] = await EnrolmentAPI.putEnrolment(data);
+  return enrolmentsData;
+};
+
+export default saveEnrolments;

--- a/src/pages/MainRegistration.tsx
+++ b/src/pages/MainRegistration.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from "react";
 
 import { Typography } from "@material-ui/core";
 
-import EnrolmentAPI from "api/EnrolmentAPI";
 import FamilyAPI from "api/FamilyAPI";
 import {
   EnrolmentRequest,
@@ -11,6 +10,7 @@ import {
 } from "api/types";
 import SpinnerOverlay from "components/common/spinner-overlay";
 import FamilySidebar from "components/families/family-sidebar";
+import saveEnrolments from "components/families/family-sidebar/utils";
 import FamilyTable from "components/families/family-table";
 import DefaultFields from "constants/DefaultFields";
 
@@ -49,13 +49,14 @@ const MainRegistration = () => {
     }
   };
 
-  const onEditFamilyCurrentEnrolment = async (data: EnrolmentRequest) => {
-    if (selectedFamily === null || selectedFamily.current_enrolment === null) {
+  const onEditFamilyEnrolment = async (data: EnrolmentRequest) => {
+    if (selectedFamily === null) {
       return;
     }
+    const enrolments = await saveEnrolments(selectedFamily.enrolments, data);
     setSelectedFamily({
       ...selectedFamily,
-      current_enrolment: await EnrolmentAPI.putEnrolment(data),
+      enrolments,
     });
     resetFamilies();
   };
@@ -79,7 +80,7 @@ const MainRegistration = () => {
           isOpen={isSidebarOpen}
           family={selectedFamily}
           onClose={() => setIsSidebarOpen(false)}
-          onEditCurrentEnrolment={onEditFamilyCurrentEnrolment}
+          onEditEnrolment={onEditFamilyEnrolment}
           onSaveFamily={onSaveFamily}
         />
       )}

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -15,7 +15,6 @@ import { makeStyles } from "@material-ui/styles";
 import { useHistory, useParams } from "react-router-dom";
 
 import ClassAPI from "api/ClassAPI";
-import EnrolmentAPI from "api/EnrolmentAPI";
 import FamilyAPI from "api/FamilyAPI";
 import SessionAPI from "api/SessionAPI";
 import {
@@ -30,6 +29,7 @@ import {
 import Spinner from "components/common/spinner";
 import SpinnerOverlay from "components/common/spinner-overlay";
 import FamilySidebar from "components/families/family-sidebar";
+import saveEnrolments from "components/families/family-sidebar/utils";
 import FamilyTable from "components/families/family-table";
 import RegistrationForm from "components/registration/registration-form";
 import RegistrationDialog from "components/registration/RegistrationDialog";
@@ -223,13 +223,14 @@ const Sessions = () => {
     }
   };
 
-  const onEditFamilyCurrentEnrolment = async (data: EnrolmentRequest) => {
-    if (selectedFamily === null || selectedFamily.current_enrolment === null) {
+  const onEditFamilyEnrolment = async (data: EnrolmentRequest) => {
+    if (selectedFamily === null) {
       return;
     }
+    const enrolments = await saveEnrolments(selectedFamily.enrolments, data);
     setSelectedFamily({
       ...selectedFamily,
-      current_enrolment: await EnrolmentAPI.putEnrolment(data),
+      enrolments,
     });
     resetSession();
   };
@@ -265,7 +266,7 @@ const Sessions = () => {
             isOpen={isSidebarOpen}
             family={selectedFamily}
             onClose={() => setIsSidebarOpen(false)}
-            onEditCurrentEnrolment={onEditFamilyCurrentEnrolment}
+            onEditEnrolment={onEditFamilyEnrolment}
             onSaveFamily={onSaveFamily}
           />
         )}

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -100,7 +100,7 @@ const Sessions = () => {
       return;
     }
     if (!sessionId) {
-      history.push(`/sessions/${sessions[0].id}`);
+      history.push(`/sessions/${sessions[sessions.length - 1].id}`);
     } else {
       updateSelectedSession(Number(sessionId));
     }


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Update logic for current enrolments to be based on whether the session is active](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=0289062affe148dba03c6eba6cd3c3ba)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- see context in the ticket
- display multiple enrolment forms if there are multiple enrolments in the sidebar
- add an empty state for previous enrolments

<img width="1536" alt="Screen Shot 2021-08-22 at 6 00 04 PM" src="https://user-images.githubusercontent.com/37346399/130371333-430501c9-9f73-47b3-a2aa-82db5409f7a0.png">

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. check out https://github.com/uwblueprint/project-read-backend/pull/118
1. set some sessions as active in the Django admin
1. register an existing client who is enrolled in an active session in another active session
2. open their sidebar and verify both sessions show up

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- testing

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
