### PR TITLE
Add sticky columns and style row colours on the attendance table

### DIFF
--- a/src/components/families/family-table/FamilyTable.tsx
+++ b/src/components/families/family-table/FamilyTable.tsx
@@ -1,7 +1,6 @@
 import React, { useContext, useCallback } from "react";
 
 import { Typography } from "@material-ui/core";
-import { grey } from "@material-ui/core/colors";
 import moment from "moment";
 import MUIDataTable, {
   MUIDataTableColumn,
@@ -13,12 +12,10 @@ import StatusChip from "components/common/status-chip";
 import DefaultFieldKey from "constants/DefaultFieldKey";
 import DefaultFields from "constants/DefaultFields";
 import EnrolmentStatus from "constants/EnrolmentStatus";
+import getHeaderColumns from "constants/MuiDatatables";
 import QuestionType from "constants/QuestionType";
 import { DynamicFieldsContext } from "context/DynamicFieldsContext";
 import { DefaultField, DynamicField } from "types";
-
-const stickyColumnWidth = 116;
-const stickyColumnPaddingX = 16;
 
 const options: MUIDataTableOptions = {
   responsive: "standard",
@@ -26,20 +23,6 @@ const options: MUIDataTableOptions = {
   rowsPerPageOptions: [25, 50, 100],
   selectableRows: "none",
   elevation: 0,
-  setTableProps: () => ({
-    style: {
-      borderCollapse: "separate",
-    },
-  }),
-};
-
-const stickyColumnStyles = {
-  backgroundColor: "inherit",
-  left: 0,
-  maxWidth: stickyColumnWidth,
-  minWidth: stickyColumnWidth,
-  position: "sticky",
-  zIndex: 101,
 };
 
 const idColumn: MUIDataTableColumn = {
@@ -134,7 +117,9 @@ const FamilyTable = ({
         ...args,
       };
       parentDynamicFields.forEach((field) => {
-        Object.assign(familyRow, { [field.id]: parent.information[field.id] });
+        Object.assign(familyRow, {
+          [field.id]: parent.information[field.id]?.split("\n").join(", "),
+        });
       });
       return familyRow;
     });
@@ -156,32 +141,6 @@ const FamilyTable = ({
       ),
     },
   });
-
-  const getStickyColumn = (
-    column: MUIDataTableColumn,
-    isLast: boolean,
-    offset: number
-  ): MUIDataTableColumn => {
-    const columnStyles = {
-      ...stickyColumnStyles,
-      left: offset,
-      ...(isLast && {
-        borderRight: `1px solid ${grey[300]}`,
-      }),
-    };
-    return {
-      ...column,
-      options: {
-        ...column.options,
-        setCellHeaderProps: () => ({
-          style: columnStyles,
-        }),
-        setCellProps: () => ({
-          style: columnStyles,
-        }),
-      },
-    };
-  };
 
   const enrolledClassColumn: MUIDataTableColumn = {
     name: DefaultFields.ENROLLED_CLASS.id,
@@ -212,12 +171,10 @@ const FamilyTable = ({
     idColumn,
 
     // sticky first and last name columns
-    getStickyColumn(getColumn(DefaultFields.FIRST_NAME, false), false, 0),
-    getStickyColumn(
+    ...getHeaderColumns([
+      getColumn(DefaultFields.FIRST_NAME, false),
       getColumn(DefaultFields.LAST_NAME, false),
-      true,
-      stickyColumnWidth + stickyColumnPaddingX * 2
-    ),
+    ]),
 
     // remaining default fields
     ...[

--- a/src/components/sessions/attendance-table/AttendanceTable.tsx
+++ b/src/components/sessions/attendance-table/AttendanceTable.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from "react";
 
 import { Box, Button, Checkbox, IconButton, Tooltip } from "@material-ui/core";
-import { Add, SupervisorAccountOutlined } from "@material-ui/icons";
-import CheckIcon from "@material-ui/icons/Check";
+import { Add, Check, SupervisorAccountOutlined } from "@material-ui/icons";
 import { KeyboardDatePicker } from "@material-ui/pickers";
 import { makeStyles } from "@material-ui/styles";
 import _ from "lodash";
@@ -53,7 +52,6 @@ const AttendanceTable = ({ classObj, isEditing, onSubmit }: Props) => {
   const [open, setOpen] = useState(false);
   const [data, setData] = useState<ClassDetailRequest>(_.cloneDeep(classObj));
   const [tableRows, setTableRows] = useState<AttendanceTableRow[]>([]);
-  const [tableColumns, setTableColumns] = useState<MUIDataTableColumn[]>([]);
 
   const handleCheckboxOnClick = (id: number, date: string) => {
     const dateIndex = data.attendance.findIndex(
@@ -100,7 +98,7 @@ const AttendanceTable = ({ classObj, isEditing, onSubmit }: Props) => {
           className={classes.button}
         >
           {!isEditing ? "Take attendance " : "Done attendance "}
-          <CheckIcon className={classes.checkmark} />
+          <Check className={classes.checkmark} />
         </Button>
         {isEditing ? (
           <>
@@ -259,20 +257,11 @@ const AttendanceTable = ({ classObj, isEditing, onSubmit }: Props) => {
       .concat(dateColumns);
   };
 
-  useEffect(() => {
-    setData(_.cloneDeep(classObj));
-    setTableColumns([]);
-  }, [classObj]);
-
-  useEffect(() => {
-    setTableColumns(getTableColumns());
-  }, [tableRows, isEditing]);
-
   return (
     <MUIDataTable
       title=""
       data={tableRows}
-      columns={tableColumns}
+      columns={getTableColumns()}
       options={options}
     />
   );

--- a/src/components/sessions/attendance-table/index.ts
+++ b/src/components/sessions/attendance-table/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AttendanceTable";

--- a/src/constants/MuiDatatables.ts
+++ b/src/constants/MuiDatatables.ts
@@ -1,0 +1,41 @@
+import { grey } from "@material-ui/core/colors";
+import { MUIDataTableColumn } from "mui-datatables";
+
+const STICKY_COLUMN_WIDTH = 116;
+const STICKY_COLUMN_PADDING_X = 16;
+
+const STICKY_COLUMN_STYLES = {
+  backgroundColor: "inherit",
+  left: 0,
+  maxWidth: STICKY_COLUMN_WIDTH,
+  minWidth: STICKY_COLUMN_WIDTH,
+  position: "sticky",
+  zIndex: 101,
+};
+
+const getHeaderColumns = (
+  columns: MUIDataTableColumn[]
+): MUIDataTableColumn[] =>
+  columns.map((column, index) => {
+    const style = {
+      ...STICKY_COLUMN_STYLES,
+      ...(index === columns.length - 1 && {
+        left: STICKY_COLUMN_WIDTH + STICKY_COLUMN_PADDING_X * 2,
+        borderRight: `1px solid ${grey[300]}`,
+      }),
+    };
+    return {
+      ...column,
+      options: {
+        ...column.options,
+        setCellHeaderProps: () => ({
+          style,
+        }),
+        setCellProps: () => ({
+          style,
+        }),
+      },
+    };
+  });
+
+export default getHeaderColumns;

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -196,7 +196,7 @@ const Sessions = () => {
       (prevMap) =>
         new Map([...Array.from(prevMap), [classObj.id, updatedClass]])
     );
-    setIsEditingAttendance(false);
+    setIsEditingAttendance(!isEditingAttendance);
   };
 
   const onSelectFamily = async (id: number | null) => {

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -33,10 +33,10 @@ import saveEnrolments from "components/families/family-sidebar/utils";
 import FamilyTable from "components/families/family-table";
 import RegistrationForm from "components/registration/registration-form";
 import RegistrationDialog from "components/registration/RegistrationDialog";
+import AttendanceTable from "components/sessions/attendance-table";
 import SessionDetailView, {
   ALL_CLASSES_TAB_INDEX,
 } from "components/sessions/session-detail-view";
-import AttendanceTable from "components/sessions/session-detail-view/AttendanceTable";
 import DefaultFields from "constants/DefaultFields";
 
 const NEW_SESSION = -1;
@@ -70,7 +70,7 @@ const Sessions = () => {
   const [classTabIndex, setClassTabIndex] = useState(ALL_CLASSES_TAB_INDEX);
   const [displayRegDialog, setDisplayRegDialog] = useState(false);
   const [isOnAttendanceView, setAttendanceView] = useState(false);
-  const [isEditingAttendance, setIsTakingAttendance] = useState(false);
+  const [isEditingAttendance, setIsEditingAttendance] = useState(false);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [
     selectedFamily,
@@ -187,7 +187,7 @@ const Sessions = () => {
   };
 
   useEffect(() => {
-    setIsTakingAttendance(false);
+    setIsEditingAttendance(false);
   }, [isOnAttendanceView, classTabIndex]);
 
   const onSubmitAttendance = async (classObj: ClassDetailRequest) => {
@@ -196,7 +196,7 @@ const Sessions = () => {
       (prevMap) =>
         new Map([...Array.from(prevMap), [classObj.id, updatedClass]])
     );
-    setIsTakingAttendance(!isEditingAttendance);
+    setIsEditingAttendance(false);
   };
 
   const onSelectFamily = async (id: number | null) => {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -32,6 +32,24 @@ const theme = createMuiTheme({
         textTransform: "none",
       },
     },
+    MUIDataTable: {
+      tableRoot: {
+        borderCollapse: "separate",
+      },
+    },
+    MUIDataTableHeadCell: {
+      root: {
+        whiteSpace: "nowrap",
+        overflow: "hidden",
+      },
+    },
+    MUIDataTableToolbar: {
+      actions: {
+        display: "flex",
+        flexDirection: "row",
+        flex: "initial",
+      },
+    },
     MuiDialogContent: {
       root: {
         paddingLeft: 48,
@@ -101,7 +119,7 @@ const theme = createMuiTheme({
       root: {
         backgroundColor: defaultTheme.palette.background.paper,
         "&$hover:hover": {
-          backgroundColor: "rgb(245, 245, 245)",
+          backgroundColor: defaultTheme.palette.background.default,
         },
       },
     },


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

n/a

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- refactored the mui datatable sticky columns to reuse across the family table & attendance table
- display different row colours based on the student's role

<img width="1535" alt="Screen Shot 2021-08-22 at 8 21 14 PM" src="https://user-images.githubusercontent.com/37346399/130374986-ad1ea889-846e-4b52-a086-57d2944a5035.png">

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. check out https://github.com/uwblueprint/project-read-backend/pull/118
1. verify things still work!

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- testing
- code correctness

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
