### PR TITLE
Add registered at column to the session/class pages

### DIFF
--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -37,13 +37,19 @@ export type SessionDetailResponse = Session & {
   families: FamilyListResponse[];
 };
 
-export type EnrolmentResponse = Enrolment & {
+export type EnrolmentResponse = Pick<
+  Enrolment,
+  "id" | "created_at" | "family" | "status" | "students"
+> & {
   session: SessionListResponse;
   preferred_class: ClassListResponse | null;
   enrolled_class: ClassListResponse | null;
 };
 
-export type EnrolmentRequest = Enrolment & {
+export type EnrolmentRequest = Pick<
+  Enrolment,
+  "id" | "family" | "status" | "students"
+> & {
   session: number;
   preferred_class: number | null;
   enrolled_class: number | null;

--- a/src/components/families/family-table/FamilyTable.tsx
+++ b/src/components/families/family-table/FamilyTable.tsx
@@ -61,6 +61,7 @@ type FamilyTableRow = Pick<
   [DefaultFieldKey.SESSION]: string;
   [DefaultFieldKey.ENROLLED_CLASS]: string;
   [DefaultFieldKey.PREFERRED_CLASS]: string;
+  [DefaultFieldKey.REGISTERED_AT]: string;
   [DefaultFieldKey.CHILDREN]: string;
   [key: number]: string | number; // dynamic fields
 };
@@ -100,11 +101,15 @@ const FamilyTable = ({
       });
 
       const enrolmentData = enrolment || {
+        created_at: null,
         enrolled_class: null,
         preferred_class: null,
         status: EnrolmentStatus.UNASSIGNED,
       };
       const familyRow: FamilyTableRow = {
+        [DefaultFieldKey.REGISTERED_AT]: enrolmentData.created_at
+          ? moment(enrolmentData.created_at).format("MMM D h:mma")
+          : "N/A",
         [DefaultFieldKey.FIRST_NAME]: parent.first_name,
         [DefaultFieldKey.LAST_NAME]: parent.last_name,
         [DefaultFieldKey.CHILDREN]: childrenInfo,
@@ -174,6 +179,9 @@ const FamilyTable = ({
 
     // sticky first and last name columns
     ...getHeaderColumns([
+      ...(enrolmentFields.includes(DefaultFields.REGISTERED_AT)
+        ? [getColumn(DefaultFields.REGISTERED_AT, false)]
+        : []),
       getColumn(DefaultFields.FIRST_NAME, false),
       getColumn(DefaultFields.LAST_NAME, false),
     ]),
@@ -192,7 +200,11 @@ const FamilyTable = ({
 
     // enrolment columns
     ...enrolmentFields
-      .filter((field) => field !== DefaultFields.ENROLLED_CLASS)
+      .filter(
+        (field) =>
+          field !== DefaultFields.REGISTERED_AT &&
+          field !== DefaultFields.ENROLLED_CLASS
+      )
       .map((field) => getColumn(field, false)),
     ...(enrolmentFields.includes(DefaultFields.ENROLLED_CLASS)
       ? [enrolledClassColumn]

--- a/src/constants/DefaultFieldKey.ts
+++ b/src/constants/DefaultFieldKey.ts
@@ -16,6 +16,7 @@ enum DefaultFieldKey {
   PREFERRED_CLASS = "preferred_class",
   PREFERRED_CONTACT = "preferred_comms",
   PREFERRED_NUMBER = "preferred_number",
+  REGISTERED_AT = "registered_at",
   SESSION = "session",
   STATUS = "status",
   WORK_NUMBER = "work_number",

--- a/src/constants/DefaultFields.ts
+++ b/src/constants/DefaultFields.ts
@@ -109,6 +109,13 @@ const DefaultFields: Record<string, DefaultField> = Object.freeze({
     question_type: QuestionType.SELECT,
     options: ["Home", "Cell", "Work"],
   },
+  REGISTERED_AT: {
+    id: DefaultFieldKey.REGISTERED_AT,
+    is_default: true,
+    name: "Registered at",
+    question_type: QuestionType.DATE,
+    options: [],
+  },
   SESSION: {
     id: DefaultFieldKey.SESSION,
     is_default: true,

--- a/src/constants/MuiDatatables.ts
+++ b/src/constants/MuiDatatables.ts
@@ -19,8 +19,10 @@ const getHeaderColumns = (
   columns.map((column, index) => {
     const style = {
       ...STICKY_COLUMN_STYLES,
+      ...(index && {
+        left: index * (STICKY_COLUMN_WIDTH + STICKY_COLUMN_PADDING_X * 2),
+      }),
       ...(index === columns.length - 1 && {
-        left: STICKY_COLUMN_WIDTH + STICKY_COLUMN_PADDING_X * 2,
         borderRight: `1px solid ${grey[300]}`,
       }),
     };

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -254,7 +254,9 @@ const Sessions = () => {
       <FamilyTable
         families={getFamilies()}
         enrolmentFields={
-          isOnAllClassesTab(classTabIndex) ? [DefaultFields.ENROLLED_CLASS] : []
+          isOnAllClassesTab(classTabIndex)
+            ? [DefaultFields.REGISTERED_AT, DefaultFields.ENROLLED_CLASS]
+            : [DefaultFields.REGISTERED_AT]
         }
         shouldDisplayDynamicFields={false}
         onSelectFamily={async (id) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -88,6 +88,7 @@ export type Class = {
 
 export type Enrolment = {
   id: number;
+  created_at: Date;
   family: number; // family id
   status: EnrolmentStatus;
   students: number[];


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

follow up to [sort families by reg time](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=04dcfa75d84b4da09435a9f98f937a60)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- added a sticky column that displays the enrolment's created_at time
<img width="1535" alt="Screen Shot 2021-08-24 at 8 22 07 PM" src="https://user-images.githubusercontent.com/37346399/130706625-71e6d563-cdfc-4a68-825b-a4a49b24126b.png">

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. open the session/class pages and verify the column shows up!

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
