### PR TITLE
Fix sidebar notes save bug

### DIFF
--- a/src/components/families/family-sidebar/FamilySidebar.tsx
+++ b/src/components/families/family-sidebar/FamilySidebar.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 
 import {
   Box,
@@ -215,12 +209,9 @@ const FamilySidebar = ({
 
   // Notes ====================================================================
 
-  const debouncedSaveFamily = useCallback(
-    debounce((notes: string) => {
-      saveFamily({ ...familyFormData, notes }, false);
-    }, 1000),
-    []
-  );
+  const debouncedSaveFamily = debounce((notes: string) => {
+    saveFamily({ ...familyFormData, notes }, false);
+  }, 1000);
 
   return (
     <Drawer


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

n/a

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- fix a bug where notes were always being saved to the first family opened 😔🐛 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. open the sidebar and edit notes of multiple different families, verify that each family's notes are updated as expected

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- testing

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
