### PR TITLE
Disable the delete option button if there is only one left

### DIFF
--- a/src/components/form-editor/field-editor/FieldEditor.tsx
+++ b/src/components/form-editor/field-editor/FieldEditor.tsx
@@ -29,6 +29,9 @@ import { DefaultField, DynamicField } from "types";
 import QuestionTypeLabel from "../question-type-label";
 import useStyles from "./styles";
 
+const DELETE_OPTION_MESSAGE =
+  "Dropdown or checkbox questions must have at least one option";
+
 // unique identifier for options
 let OPTION_KEY_COUNTER = 1;
 
@@ -316,16 +319,8 @@ const FieldEditor = ({
                   />
                 </FormRow>
                 <Tooltip
-                  aria-label={
-                    deleteOptionDisabled
-                      ? "Dropdown or checkbox questions must have at least one option"
-                      : ""
-                  }
-                  title={
-                    deleteOptionDisabled
-                      ? "Dropdown or checkbox questions must have at least one option"
-                      : ""
-                  }
+                  aria-label={deleteOptionDisabled ? DELETE_OPTION_MESSAGE : ""}
+                  title={deleteOptionDisabled ? DELETE_OPTION_MESSAGE : ""}
                 >
                   <span>
                     <IconButton

--- a/src/components/form-editor/field-editor/FieldEditor.tsx
+++ b/src/components/form-editor/field-editor/FieldEditor.tsx
@@ -12,6 +12,7 @@ import {
   Radio,
   Select,
   Switch,
+  Tooltip,
   Typography,
 } from "@material-ui/core";
 import { Clear, DragIndicator, EditOutlined } from "@material-ui/icons";
@@ -101,6 +102,8 @@ const FieldEditor = ({
     options[optionIndex] = data;
     setFieldFormData({ ...fieldFormData, options });
   };
+
+  const deleteOptionDisabled = fieldFormData.options.length <= 1;
 
   const onDeleteOption = (index: number): void => {
     setFieldFormData({
@@ -312,13 +315,29 @@ const FieldEditor = ({
                     value={option.value}
                   />
                 </FormRow>
-                <IconButton
-                  aria-label="Delete option"
-                  onClick={() => onDeleteOption(option.index)}
-                  size="small"
+                <Tooltip
+                  aria-label={
+                    deleteOptionDisabled
+                      ? "Dropdown or checkbox questions must have at least one option"
+                      : ""
+                  }
+                  title={
+                    deleteOptionDisabled
+                      ? "Dropdown or checkbox questions must have at least one option"
+                      : ""
+                  }
                 >
-                  <Clear fontSize="small" />
-                </IconButton>
+                  <span>
+                    <IconButton
+                      aria-label="Delete option"
+                      disabled={deleteOptionDisabled}
+                      onClick={() => onDeleteOption(option.index)}
+                      size="small"
+                    >
+                      <Clear fontSize="small" />
+                    </IconButton>
+                  </span>
+                </Tooltip>
               </Box>
             ))}
             <Box display="flex" alignItems="center">


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[edit field component](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=f7211296e7ca48f1b1b1bb98b47dfeca)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- disable the delete button & display a tooltip if there is only one option left on the checkbox/dropdown questions
<img width="817" alt="Screen Shot 2021-08-24 at 1 25 23 PM" src="https://user-images.githubusercontent.com/37346399/130661950-cad361ab-e9cc-4426-9634-595b576c1709.png">

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. option a dropdown/checkbox q and verify that you can't remove all options

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- testing

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
