### PR TITLE
Allow users to create dynamic fields

### DIFF
--- a/src/api/DynamicFieldAPI.ts
+++ b/src/api/DynamicFieldAPI.ts
@@ -10,9 +10,14 @@ const getFields = async (): Promise<DynamicFieldsResponse> => {
   return res[0]; // API returns the content as the first element of an array
 };
 
-const putField = async (
+const postField = async (
   data: DynamicFieldRequest
+): Promise<DynamicFieldResponse> =>
+  (await APIUtils.post(`/fields/`, data)) as DynamicFieldResponse;
+
+const putField = async (
+  data: DynamicFieldRequest & { id: number }
 ): Promise<DynamicFieldResponse> =>
   (await APIUtils.put(`/fields/${data.id}/`, data)) as DynamicFieldResponse;
 
-export default { getFields, putField };
+export default { getFields, postField, putField };

--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -153,5 +153,5 @@ export type DynamicFieldsResponse = {
 
 export type DynamicFieldRequest = Pick<
   DynamicField,
-  "id" | "name" | "options" | "question_type"
+  "is_default" | "name" | "options" | "order" | "question_type" | "role"
 >;

--- a/src/components/common/add-button/AddButton.tsx
+++ b/src/components/common/add-button/AddButton.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+import { Button } from "@material-ui/core";
+import { Add } from "@material-ui/icons";
+
+import useStyles from "./styles";
+
+type Props = {
+  disabled?: boolean;
+  label: string;
+  onClick: () => void;
+};
+
+const AddButton = ({ disabled = false, label, onClick }: Props) => {
+  const classes = useStyles();
+  return (
+    <Button
+      className={classes.button}
+      disabled={disabled}
+      onClick={onClick}
+      size="medium"
+      variant="outlined"
+    >
+      <Add fontSize="small" className={classes.buttonIcon} />
+      {label}
+    </Button>
+  );
+};
+
+export default AddButton;

--- a/src/components/common/add-button/index.ts
+++ b/src/components/common/add-button/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddButton";

--- a/src/components/common/add-button/styles.ts
+++ b/src/components/common/add-button/styles.ts
@@ -1,0 +1,13 @@
+import { makeStyles } from "@material-ui/styles";
+
+const useStyles = makeStyles(() => ({
+  button: {
+    paddingLeft: 12,
+    paddingRight: 12,
+  },
+  buttonIcon: {
+    marginRight: 8,
+  },
+}));
+
+export default useStyles;

--- a/src/components/common/form-action-icon-buttons/FormActionIconButtons.tsx
+++ b/src/components/common/form-action-icon-buttons/FormActionIconButtons.tsx
@@ -1,16 +1,21 @@
 import React from "react";
 
-import { IconButton } from "@material-ui/core";
+import { IconButton, Tooltip } from "@material-ui/core";
 import { Check, DeleteOutline } from "@material-ui/icons";
 
 import useStyles from "./styles";
 
 type Props = {
+  errorMessage?: string;
   onDelete: () => void;
   onSubmit: () => void;
 };
 
-const FormActionIconButtons = ({ onDelete, onSubmit }: Props) => {
+const FormActionIconButtons = ({
+  errorMessage = "",
+  onDelete,
+  onSubmit,
+}: Props) => {
   const classes = useStyles();
   return (
     <>
@@ -22,14 +27,19 @@ const FormActionIconButtons = ({ onDelete, onSubmit }: Props) => {
       >
         <DeleteOutline />
       </IconButton>
-      <IconButton
-        aria-label="save"
-        className={classes.formActionButton}
-        onClick={onSubmit}
-        size="small"
-      >
-        <Check />
-      </IconButton>
+      <Tooltip aria-label={errorMessage} title={errorMessage}>
+        <span>
+          <IconButton
+            aria-label="save"
+            className={classes.formActionButton}
+            disabled={errorMessage.length > 0}
+            onClick={onSubmit}
+            size="small"
+          >
+            <Check />
+          </IconButton>
+        </span>
+      </Tooltip>
     </>
   );
 };

--- a/src/components/form-editor/FormEditor.tsx
+++ b/src/components/form-editor/FormEditor.tsx
@@ -67,7 +67,7 @@ const FormEditor = ({
       {parentDynamicFields.map((field) => (
         <FieldEditor
           key={field.id}
-          existingId={field.id}
+          existingFieldId={field.id}
           field={field}
           isEnabled={enabledFieldIds.includes(field.id)}
           isReadOnly={isReadOnly}
@@ -104,7 +104,7 @@ const FormEditor = ({
       {childDynamicFields.map((field) => (
         <FieldEditor
           key={field.id}
-          existingId={field.id}
+          existingFieldId={field.id}
           field={field}
           isEnabled={enabledFieldIds.includes(field.id)}
           isReadOnly={isReadOnly}
@@ -138,7 +138,7 @@ const FormEditor = ({
       {guestDynamicFields.map((field) => (
         <FieldEditor
           key={field.id}
-          existingId={field.id}
+          existingFieldId={field.id}
           field={field}
           isEnabled={enabledFieldIds.includes(field.id)}
           isReadOnly={isReadOnly}
@@ -169,7 +169,7 @@ const FormEditor = ({
       {sessionDynamicFields.map((field) => (
         <FieldEditor
           key={field.id}
-          existingId={field.id}
+          existingFieldId={field.id}
           field={field}
           isEnabled={enabledFieldIds.includes(field.id)}
           isReadOnly={isReadOnly}

--- a/src/components/form-editor/FormEditor.tsx
+++ b/src/components/form-editor/FormEditor.tsx
@@ -1,12 +1,16 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 
 import { Box, Typography } from "@material-ui/core";
 
 import DefaultFields from "constants/DefaultFields";
+import StudentRole from "constants/StudentRole";
 import { DynamicFieldsContext } from "context/DynamicFieldsContext";
 
 import { DEFAULT_FAMILY_FIELDS, DEFAULT_STUDENT_FIELDS } from "./constants";
 import FieldEditor from "./field-editor";
+import NewFieldEditor, {
+  NewDynamicField,
+} from "./new-field-editor/NewFieldEditor";
 import useStyles from "./styles";
 
 type Props = {
@@ -28,6 +32,20 @@ const FormEditor = ({
   } = useContext(DynamicFieldsContext).dynamicFields;
   const classes = useStyles();
 
+  const [newParentField, setNewParentField] = useState<NewDynamicField | null>(
+    null
+  );
+  const [newChildField, setNewChildField] = useState<NewDynamicField | null>(
+    null
+  );
+  const [newGuestField, setNewGuestField] = useState<NewDynamicField | null>(
+    null
+  );
+  const [
+    newSessionField,
+    setNewSessionField,
+  ] = useState<NewDynamicField | null>(null);
+
   const handleChangeEnabledField = (id: number, enabled: boolean) =>
     enabled
       ? onChangeEnabledFieldIds([...enabledFieldIds, id])
@@ -39,19 +57,35 @@ const FormEditor = ({
         Basic information
       </Typography>
       {DEFAULT_STUDENT_FIELDS.concat(DEFAULT_FAMILY_FIELDS).map((field) => (
-        <FieldEditor key={field.id} field={field} isReadOnly={isReadOnly} />
+        <FieldEditor
+          key={field.id}
+          field={field}
+          isReadOnly={isReadOnly}
+          role={StudentRole.PARENT}
+        />
       ))}
       {parentDynamicFields.map((field) => (
         <FieldEditor
           key={field.id}
+          existingId={field.id}
           field={field}
           isEnabled={enabledFieldIds.includes(field.id)}
           isReadOnly={isReadOnly}
           onChangeEnabled={(enabled) =>
             handleChangeEnabledField(field.id, enabled)
           }
+          role={StudentRole.PARENT}
         />
       ))}
+      {!isReadOnly && (
+        <NewFieldEditor
+          existingFields={parentDynamicFields}
+          newField={newParentField}
+          onAdd={(data) => setNewParentField(data)}
+          onSubmit={() => setNewParentField(null)}
+          role={StudentRole.PARENT}
+        />
+      )}
 
       <Typography component="h2" variant="h3" className={classes.heading}>
         Family members
@@ -60,36 +94,69 @@ const FormEditor = ({
         Children
       </Typography>
       {DEFAULT_STUDENT_FIELDS.map((field) => (
-        <FieldEditor key={field.id} field={field} isReadOnly={isReadOnly} />
+        <FieldEditor
+          key={field.id}
+          field={field}
+          isReadOnly={isReadOnly}
+          role={StudentRole.CHILD}
+        />
       ))}
       {childDynamicFields.map((field) => (
         <FieldEditor
           key={field.id}
+          existingId={field.id}
           field={field}
           isEnabled={enabledFieldIds.includes(field.id)}
           isReadOnly={isReadOnly}
           onChangeEnabled={(enabled) =>
             handleChangeEnabledField(field.id, enabled)
           }
+          role={StudentRole.CHILD}
         />
       ))}
+      {!isReadOnly && (
+        <NewFieldEditor
+          existingFields={childDynamicFields}
+          newField={newChildField}
+          onAdd={(data) => setNewChildField(data)}
+          onSubmit={() => setNewChildField(null)}
+          role={StudentRole.CHILD}
+        />
+      )}
+
       <Typography component="h3" variant="h4" className={classes.subHeading}>
         Additional members
       </Typography>
       {DEFAULT_STUDENT_FIELDS.map((field) => (
-        <FieldEditor key={field.id} field={field} isReadOnly={isReadOnly} />
+        <FieldEditor
+          key={field.id}
+          field={field}
+          isReadOnly={isReadOnly}
+          role={StudentRole.GUEST}
+        />
       ))}
       {guestDynamicFields.map((field) => (
         <FieldEditor
           key={field.id}
+          existingId={field.id}
           field={field}
           isEnabled={enabledFieldIds.includes(field.id)}
           isReadOnly={isReadOnly}
           onChangeEnabled={(enabled) =>
             handleChangeEnabledField(field.id, enabled)
           }
+          role={StudentRole.GUEST}
         />
       ))}
+      {!isReadOnly && (
+        <NewFieldEditor
+          existingFields={guestDynamicFields}
+          newField={newGuestField}
+          onAdd={(data) => setNewGuestField(data)}
+          onSubmit={() => setNewGuestField(null)}
+          role={StudentRole.GUEST}
+        />
+      )}
 
       <Typography component="h2" variant="h3" className={classes.heading}>
         Session questions
@@ -97,18 +164,30 @@ const FormEditor = ({
       <FieldEditor
         field={DefaultFields.PREFERRED_CLASS}
         isReadOnly={isReadOnly}
+        role={StudentRole.SESSION}
       />
       {sessionDynamicFields.map((field) => (
         <FieldEditor
           key={field.id}
+          existingId={field.id}
           field={field}
           isEnabled={enabledFieldIds.includes(field.id)}
           isReadOnly={isReadOnly}
           onChangeEnabled={(enabled) =>
             handleChangeEnabledField(field.id, enabled)
           }
+          role={StudentRole.SESSION}
         />
       ))}
+      {!isReadOnly && (
+        <NewFieldEditor
+          existingFields={sessionDynamicFields}
+          newField={newSessionField}
+          onAdd={(data) => setNewSessionField(data)}
+          onSubmit={() => setNewSessionField(null)}
+          role={StudentRole.SESSION}
+        />
+      )}
     </Box>
   );
 };

--- a/src/components/form-editor/field-editor/FieldEditor.tsx
+++ b/src/components/form-editor/field-editor/FieldEditor.tsx
@@ -62,7 +62,7 @@ export type FieldFormData = (
 };
 
 type Props = {
-  existingId?: number | null;
+  existingFieldId?: number | null;
   field: DefaultField | Omit<DynamicField, "id">;
   isEnabled?: boolean;
   isReadOnly: boolean;
@@ -72,7 +72,7 @@ type Props = {
 };
 
 const FieldEditor = ({
-  existingId = null,
+  existingFieldId = null,
   field,
   isEnabled = true,
   isReadOnly,
@@ -82,7 +82,9 @@ const FieldEditor = ({
   const { fetchDynamicFields } = useContext(DynamicFieldsContext);
   const isDefault = field.type === FieldType.Default;
   const classes = useStyles({ isDefault });
-  const [isEditing, setIsEditing] = useState(!isDefault && existingId === null);
+  const [isEditing, setIsEditing] = useState(
+    !isDefault && existingFieldId === null
+  );
   const [fieldFormData, setFieldFormData] = useState<FieldFormData>({
     ...field,
     options: field.options.map((option) => ({
@@ -102,8 +104,8 @@ const FieldEditor = ({
     if (field.type === FieldType.Default) {
       return field.id;
     }
-    if (existingId) {
-      return existingId;
+    if (existingFieldId) {
+      return existingFieldId;
     }
     return `new ${field.role} field`;
   };
@@ -146,10 +148,10 @@ const FieldEditor = ({
       options = fieldFormData.options.map((option) => option.value);
     }
     try {
-      if (existingId !== null) {
+      if (existingFieldId !== null) {
         await DynamicFieldAPI.putField({
           ...fieldFormData,
-          id: existingId,
+          id: existingFieldId,
           options,
           order: field.order,
           role: field.role,

--- a/src/components/form-editor/field-editor/FieldEditor.tsx
+++ b/src/components/form-editor/field-editor/FieldEditor.tsx
@@ -80,7 +80,7 @@ const FieldEditor = ({
   onSubmit = () => {},
 }: Props) => {
   const { fetchDynamicFields } = useContext(DynamicFieldsContext);
-  const isDefault = field?.type === FieldType.Default;
+  const isDefault = field.type === FieldType.Default;
   const classes = useStyles({ isDefault });
   const [isEditing, setIsEditing] = useState(!isDefault && existingId === null);
   const [fieldFormData, setFieldFormData] = useState<FieldFormData>({
@@ -99,7 +99,7 @@ const FieldEditor = ({
   ] = useState(false);
 
   const getId = () => {
-    if (field?.type === FieldType.Default) {
+    if (field.type === FieldType.Default) {
       return field.id;
     }
     if (existingId) {
@@ -137,7 +137,7 @@ const FieldEditor = ({
     fieldFormData.name.length === 0 ? "Please enter a question name" : "";
 
   const onSubmitField = async () => {
-    if (field?.type === FieldType.Default) {
+    if (field.type === FieldType.Default) {
       return;
     }
 

--- a/src/components/form-editor/field-editor/FieldEditor.tsx
+++ b/src/components/form-editor/field-editor/FieldEditor.tsx
@@ -113,7 +113,13 @@ const FieldEditor = ({
   const onAddOption = (): void => {
     setFieldFormData({
       ...fieldFormData,
-      options: [...fieldFormData.options, { index: generateKey(), value: "" }],
+      options: [
+        ...fieldFormData.options,
+        {
+          index: generateKey(),
+          value: `Option ${fieldFormData.options.length + 1}`,
+        },
+      ],
     });
   };
 

--- a/src/components/form-editor/new-field-editor/NewFieldEditor.tsx
+++ b/src/components/form-editor/new-field-editor/NewFieldEditor.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+
+import { Box, Tooltip } from "@material-ui/core";
+
+import AddButton from "components/common/add-button";
+import QuestionType from "constants/QuestionType";
+import StudentRole from "constants/StudentRole";
+import { DynamicField, FieldType } from "types";
+
+import FieldEditor from "../field-editor";
+
+export type NewDynamicField = Omit<DynamicField, "id">;
+
+const getMaxOrder = (fields: DynamicField[]): number =>
+  fields.reduce((a, b) => (a.order > b.order ? a : b)).order;
+
+const getNewDynamicFieldData = (
+  role: StudentRole,
+  order: number
+): NewDynamicField => ({
+  is_default: false,
+  name: "",
+  options: ["Option 1"],
+  order,
+  question_type: QuestionType.TEXT,
+  role,
+  type: FieldType.Dynamic,
+});
+
+type Props = {
+  existingFields: DynamicField[];
+  newField: NewDynamicField | null;
+  onAdd: (data: NewDynamicField) => void;
+  onSubmit: () => void;
+  role: StudentRole;
+};
+
+const NewFieldEditor = ({
+  existingFields,
+  newField,
+  onAdd,
+  onSubmit,
+  role,
+}: Props) => {
+  const isAddDisabled = newField !== null;
+  return (
+    <>
+      {newField && (
+        <FieldEditor
+          field={newField}
+          isReadOnly={false}
+          onSubmit={onSubmit}
+          role={StudentRole.CHILD}
+        />
+      )}
+      <Box marginY={2}>
+        <Tooltip
+          aria-label={
+            isAddDisabled
+              ? "Save your current question before adding a new one"
+              : ""
+          }
+          title={
+            isAddDisabled
+              ? "Save your current question before adding a new one"
+              : ""
+          }
+        >
+          <span>
+            <AddButton
+              disabled={isAddDisabled}
+              label="Add a question"
+              onClick={() =>
+                onAdd(
+                  getNewDynamicFieldData(role, getMaxOrder(existingFields) + 1)
+                )
+              }
+            />
+          </span>
+        </Tooltip>
+      </Box>
+    </>
+  );
+};
+
+export default NewFieldEditor;

--- a/src/components/form-editor/new-field-editor/index.ts
+++ b/src/components/form-editor/new-field-editor/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NewFieldEditor";

--- a/src/components/sessions/add-classes/AddClasses.tsx
+++ b/src/components/sessions/add-classes/AddClasses.tsx
@@ -2,7 +2,6 @@ import React, { useState, useContext } from "react";
 
 import {
   Box,
-  Button,
   Divider,
   IconButton,
   MenuItem,
@@ -10,9 +9,10 @@ import {
   Select,
   Typography,
 } from "@material-ui/core";
-import { Add, RemoveCircle } from "@material-ui/icons";
+import { RemoveCircle } from "@material-ui/icons";
 
 import { ClassListRequest } from "api/types";
+import AddButton from "components/common/add-button";
 import FormRow from "components/common/form-row";
 import FieldVariant from "constants/FieldVariant";
 import QuestionType from "constants/QuestionType";
@@ -214,15 +214,9 @@ const AddClasses = ({ classList, onChangeClasses }: Props) => {
                 </Box>
               </Box>
             ))}
-            <Button
-              onClick={onAddClass}
-              className={classes.addButton}
-              size="medium"
-              variant="outlined"
-            >
-              <Add fontSize="small" className={classes.addButtonIcon} />
-              Add class
-            </Button>
+            <Box marginBottom={6} marginTop={1} marginLeft={4}>
+              <AddButton label="Add class" onClick={onAddClass} />
+            </Box>
           </Box>
         </Box>
       </Box>

--- a/src/components/sessions/add-classes/styles.ts
+++ b/src/components/sessions/add-classes/styles.ts
@@ -3,16 +3,6 @@ import { grey } from "@material-ui/core/colors";
 import { makeStyles } from "@material-ui/styles";
 
 const useStyles = makeStyles<Theme>(() => ({
-  addButton: {
-    marginBottom: 48,
-    marginLeft: 32,
-    marginTop: 10,
-    paddingLeft: 12,
-    paddingRight: 12,
-  },
-  addButtonIcon: {
-    marginRight: 8,
-  },
   deleteButton: {
     height: 16,
     width: 16,


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[allow users to add fields](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=2b0b797a18ba4261aac8f49323b8997a)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- turned the add button into a reusable component
- created a `NewFieldEditor` that includes a field editor and an add button
  - only allowed adding one field per section at a time to simplify logic
- added some placeholders & max char limits that align with our backend
- the new field takes a sec to load - made [this ticket](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=8a987bfd1b784771a82c85dd2c1af2d1) to add a loading spinner later

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. open the field settings page and try adding fields

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- testing
- code readability

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
