### PR TITLE
Implement view-only users page

### DIFF
--- a/src/api/types/index.ts
+++ b/src/api/types/index.ts
@@ -11,7 +11,16 @@ import {
   User,
 } from "types";
 
-export type UserResponse = Pick<User, "id" | "first_name" | "last_name">;
+export type UserResponse = Pick<
+  User,
+  | "id"
+  | "date_joined"
+  | "email"
+  | "first_name"
+  | "is_active"
+  | "is_admin"
+  | "last_name"
+>;
 
 export type ClassListResponse = Pick<Class, "id" | "name" | "colour">;
 

--- a/src/pages/users/Users.tsx
+++ b/src/pages/users/Users.tsx
@@ -1,7 +1,10 @@
 import React, { useContext } from "react";
 
 import {
+  Button,
+  MenuItem,
   Paper,
+  Select,
   Table,
   TableCell,
   TableContainer,
@@ -9,15 +12,31 @@ import {
   TableRow,
   Typography,
 } from "@material-ui/core";
+import moment from "moment";
 
+import FormRow from "components/common/form-row";
+import FieldVariant from "constants/FieldVariant";
+import QuestionType from "constants/QuestionType";
 import { UsersContext } from "context/UsersContext";
 
+import useStyles from "./styles";
+
+enum UserRole {
+  Admin = "Admin",
+  Facilitator = "Facilitator",
+}
+
 const Users = () => {
+  const classes = useStyles();
   const { users } = useContext(UsersContext);
   return (
     <>
       <Typography variant="h1">Manage users</Typography>
-      <TableContainer component={Paper} elevation={0}>
+      <TableContainer
+        className={classes.tableContainer}
+        component={Paper}
+        elevation={0}
+      >
         <Table aria-label="users table">
           <TableHead>
             <TableRow>
@@ -30,11 +49,60 @@ const Users = () => {
           </TableHead>
           {users.map((user) => (
             <TableRow>
-              <TableCell>email {user.id}</TableCell>
-              <TableCell>role</TableCell>
-              <TableCell>date added</TableCell>
-              <TableCell>status</TableCell>
-              <TableCell />
+              <TableCell>{user.email}</TableCell>
+              <TableCell className={classes.roleSelectTabelCell}>
+                <FormRow
+                  id={`${user.id} role`}
+                  label={`${user.id} role`}
+                  multiple={false}
+                  questionType={QuestionType.SELECT}
+                  variant={FieldVariant.COMPACT}
+                >
+                  <Select
+                    aria-label={`${user.id} role`}
+                    className={classes.roleSelect}
+                    disabled // TODO: enable when put endpoint is ready
+                    disableUnderline
+                    displayEmpty
+                    fullWidth
+                    labelId={`${user.id} role`}
+                    onChange={() => {
+                      // TODO: call put endpoint
+                    }}
+                    value={
+                      user.is_admin ? UserRole.Admin : UserRole.Facilitator
+                    }
+                  >
+                    <MenuItem
+                      className={classes.roleSelect}
+                      value={UserRole.Admin}
+                    >
+                      {UserRole.Admin}
+                    </MenuItem>
+                    <MenuItem
+                      className={classes.roleSelect}
+                      value={UserRole.Facilitator}
+                    >
+                      {UserRole.Facilitator}
+                    </MenuItem>
+                  </Select>
+                </FormRow>
+              </TableCell>
+              <TableCell>
+                {moment(user.date_joined).format("MMMM D, YYYY")}
+              </TableCell>
+              <TableCell>{user.is_active ? "Active" : "Inactive"}</TableCell>
+              <TableCell>
+                <Button
+                  className={classes.activationButton}
+                  disabled // TODO: enable when put endpoint is ready
+                  onClick={() => {
+                    // TODO: call put endpoint
+                  }}
+                >
+                  {user.is_active ? "Deactivate" : "Activate"}
+                </Button>
+              </TableCell>
             </TableRow>
           ))}
         </Table>

--- a/src/pages/users/Users.tsx
+++ b/src/pages/users/Users.tsx
@@ -1,0 +1,46 @@
+import React, { useContext } from "react";
+
+import {
+  Paper,
+  Table,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@material-ui/core";
+
+import { UsersContext } from "context/UsersContext";
+
+const Users = () => {
+  const { users } = useContext(UsersContext);
+  return (
+    <>
+      <Typography variant="h1">Manage users</Typography>
+      <TableContainer component={Paper} elevation={0}>
+        <Table aria-label="users table">
+          <TableHead>
+            <TableRow>
+              <TableCell>Email</TableCell>
+              <TableCell>Role</TableCell>
+              <TableCell>Date added</TableCell>
+              <TableCell>Status</TableCell>
+              <TableCell>Activation</TableCell>
+            </TableRow>
+          </TableHead>
+          {users.map((user) => (
+            <TableRow>
+              <TableCell>email {user.id}</TableCell>
+              <TableCell>role</TableCell>
+              <TableCell>date added</TableCell>
+              <TableCell>status</TableCell>
+              <TableCell />
+            </TableRow>
+          ))}
+        </Table>
+      </TableContainer>
+    </>
+  );
+};
+
+export default Users;

--- a/src/pages/users/index.ts
+++ b/src/pages/users/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Users";

--- a/src/pages/users/styles.ts
+++ b/src/pages/users/styles.ts
@@ -1,0 +1,26 @@
+import { makeStyles } from "@material-ui/styles";
+
+const useStyles = makeStyles(() => ({
+  activationButton: {
+    fontWeight: 400,
+    textDecoration: "underline",
+    "&:hover": {
+      textDecoration: "underline",
+    },
+  },
+  roleSelect: {
+    fontSize: 14,
+    paddingBottom: 0,
+    paddingTop: 0,
+    height: 32,
+  },
+  roleSelectTabelCell: {
+    paddingBottom: 0,
+    paddingTop: 0,
+  },
+  tableContainer: {
+    marginTop: 32,
+  },
+}));
+
+export default useStyles;

--- a/src/shared/Navbar.tsx
+++ b/src/shared/Navbar.tsx
@@ -58,17 +58,13 @@ function Navbar() {
               horizontal: "right",
             }}
           >
+            <Link to="/users" className={classes.link}>
+              <MenuItem>Manage users</MenuItem>
+            </Link>
             <Link to="/fields" className={classes.link}>
               <MenuItem>Configure global questions</MenuItem>
             </Link>
-            <MenuItem
-              onClick={() => {
-                handleClose();
-                app.auth().signOut();
-              }}
-            >
-              Logout
-            </MenuItem>
+            <MenuItem onClick={() => app.auth().signOut()}>Logout</MenuItem>
           </Menu>
         </div>
       </Toolbar>

--- a/src/shared/ProjectREAD.jsx
+++ b/src/shared/ProjectREAD.jsx
@@ -12,6 +12,7 @@ import GlobalFields from "pages/global-fields";
 import MainRegistration from "pages/MainRegistration";
 import NotFound from "pages/not-found";
 import Sessions from "pages/Sessions";
+import Users from "pages/users";
 
 import Navbar from "./Navbar";
 import PrivateRoute from "./PrivateRoute";
@@ -40,6 +41,7 @@ function ProjectREAD() {
                 component={Sessions}
               />
               <PrivateRoute exact path="/fields" component={GlobalFields} />
+              <PrivateRoute exact path="/users" component={Users} />
               <PrivateRoute exact path="/oops" component={NotFound} />
               <Redirect to="/oops" />
             </Switch>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,7 +14,11 @@ export enum DaysOfWeek {
 
 export type User = {
   id: number;
+  date_joined: Date;
+  email: string;
   first_name: string;
+  is_active: boolean;
+  is_admin: boolean;
   last_name: string;
 };
 


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[view-only users page](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=ab9202055c374731b6e54d686d220c2a)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- updated the UserResponse type to reflect additions in https://github.com/uwblueprint/project-read-backend/pull/122
- registered a /users route that goes to the Users page
- displayed the values in the UsersContext in a table
<img width="1536" alt="Screen Shot 2021-08-24 at 9 29 42 PM" src="https://user-images.githubusercontent.com/37346399/130711339-1f923d14-0a44-424e-b518-7afeb601ca9f.png">

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. run the backend on https://github.com/uwblueprint/project-read-backend/pull/122
2. navigate to the users page through the account icon
3. check out the table!

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- testing
- code readability

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
