### PR TITLE
call fields delete endpoint from client only for existing fields

### DIFF
--- a/src/api/APIUtils.ts
+++ b/src/api/APIUtils.ts
@@ -69,3 +69,19 @@ export const put = async (path: string, data: unknown): Promise<unknown> => {
 
   return res.json();
 };
+
+export const destroy = async (path: string): Promise<unknown> => {
+  const token = await getIdToken();
+  const res = await fetch(url + path, {
+    method: "DELETE",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!res.ok) {
+    throw Error(res.statusText);
+  }
+
+  return res.status;
+};

--- a/src/api/DynamicFieldAPI.ts
+++ b/src/api/DynamicFieldAPI.ts
@@ -23,4 +23,7 @@ const putField = async (
 ): Promise<DynamicFieldResponse> =>
   (await APIUtils.put(`/fields/${data.id}/`, data)) as DynamicFieldResponse;
 
-export default { exportFields, getFields, postField, putField };
+const deleteField = async (id: number): Promise<Number> =>
+  (await APIUtils.destroy(`/fields/${id}/`)) as Number;
+
+export default { exportFields, getFields, postField, putField, deleteField };

--- a/src/components/form-editor/field-editor/FieldEditor.tsx
+++ b/src/components/form-editor/field-editor/FieldEditor.tsx
@@ -181,8 +181,10 @@ const FieldEditor = ({
 
   const onDeleteField = async () => {
     try {
-      // TODO: call delete endpoint
-      fetchDynamicFields();
+      if (existingFieldId) {
+        await DynamicFieldAPI.deleteField(Number(existingFieldId));
+        fetchDynamicFields();
+      }
     } catch (err) {
       // eslint-disable-next-line no-alert
       alert(err);


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Delete fields](https://www.notion.so/uwblueprintexecs/Allow-users-to-delete-fields-331d40a269894065b8d60bf3dc1e45d2)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- add destroy action to API utils (didn't use delete since it's a keyword)
- make a function to call delete field endpoint
- call deleteField from FieldEditor

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. run backend on https://github.com/uwblueprint/project-read-backend/pull/124
2. go to configure global questions
2. click on pencil next to a dynamic field
3. click on trash can to delete
4. go to Django admin and check the field is marked as deleted


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- testing
- completeness (what else would be good to add?)

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
