### PR TITLE
change notes section overflow behavior to scroll instead of expand input box

### DIFF
--- a/src/components/families/family-sidebar/FamilySidebar.tsx
+++ b/src/components/families/family-sidebar/FamilySidebar.tsx
@@ -15,7 +15,6 @@ import {
   Button,
   InputBase,
 } from "@material-ui/core";
-import { makeStyles } from "@material-ui/core/styles";
 import { Add, Edit } from "@material-ui/icons";
 import debounce from "lodash/debounce";
 import moment from "moment";
@@ -35,58 +34,7 @@ import EnrolmentForm from "./enrolment-form";
 import FamilySidebarForm, { familySidebarFormId } from "./family-sidebar-form";
 import InteractionCard from "./interaction-card";
 import PreviousEnrolmentCard from "./previous-enrolment-card";
-
-const DRAWER_WIDTH = 416;
-
-const useStyles = makeStyles((theme) => ({
-  actionButton: {
-    backgroundColor: theme.palette.backgroundSecondary.default,
-    borderRadius: 8,
-    height: 40,
-    width: 40,
-  },
-  actionButtonIcon: {
-    height: 20,
-    width: 20,
-  },
-  drawer: {
-    width: DRAWER_WIDTH,
-  },
-  drawerPaper: {
-    backgroundColor: theme.palette.backgroundSecondary.paper,
-    borderLeft: "none",
-    height: "calc(100% - 64px)",
-    marginTop: 64,
-    width: DRAWER_WIDTH,
-  },
-  formActionRow: {
-    backgroundColor: theme.palette.backgroundSecondary.paper,
-    boxShadow: "rgb(0 0 0 / 12%) 8px 0px 8px 0px",
-    zIndex: theme.zIndex.appBar + 1,
-  },
-  heading: {
-    fontWeight: 700,
-    fontSize: 18,
-    paddingBottom: 20,
-    paddingTop: 20,
-  },
-  notes: {
-    alignItems: "baseline",
-    backgroundColor: theme.palette.backgroundSecondary.default,
-    borderRadius: 4,
-    fontSize: 14,
-    height: 150,
-    overflowY: "scroll",
-    padding: 16,
-  },
-  notesLabel: {
-    display: "none",
-  },
-  submitButton: {
-    marginLeft: 12,
-    marginRight: 24,
-  },
-}));
+import useStyles from "./styles";
 
 type Props = {
   family: FamilyDetailResponse;
@@ -413,7 +361,6 @@ const FamilySidebar = ({
           justifyContent="flex-end"
           paddingY={2}
           position="fixed"
-          width={DRAWER_WIDTH}
         >
           <Button
             onClick={() => onToggleEdit(false)}

--- a/src/components/families/family-sidebar/FamilySidebar.tsx
+++ b/src/components/families/family-sidebar/FamilySidebar.tsx
@@ -75,8 +75,8 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: theme.palette.backgroundSecondary.default,
     borderRadius: 4,
     fontSize: 14,
-    height: "fit-content",
-    minHeight: 150,
+    height: 150,
+    overflowY: "scroll",
     padding: 16,
   },
   notesLabel: {

--- a/src/components/families/family-sidebar/styles.ts
+++ b/src/components/families/family-sidebar/styles.ts
@@ -1,0 +1,56 @@
+import { makeStyles } from "@material-ui/core/styles";
+
+const DRAWER_WIDTH = 416;
+
+const useStyles = makeStyles((theme) => ({
+  actionButton: {
+    backgroundColor: theme.palette.backgroundSecondary.default,
+    borderRadius: 8,
+    height: 40,
+    width: 40,
+  },
+  actionButtonIcon: {
+    height: 20,
+    width: 20,
+  },
+  drawer: {
+    width: DRAWER_WIDTH,
+  },
+  drawerPaper: {
+    backgroundColor: theme.palette.backgroundSecondary.paper,
+    borderLeft: "none",
+    height: "calc(100% - 64px)",
+    marginTop: 64,
+    width: DRAWER_WIDTH,
+  },
+  formActionRow: {
+    backgroundColor: theme.palette.backgroundSecondary.paper,
+    boxShadow: "rgb(0 0 0 / 12%) 8px 0px 8px 0px",
+    zIndex: theme.zIndex.appBar + 1,
+    width: DRAWER_WIDTH,
+  },
+  heading: {
+    fontWeight: 700,
+    fontSize: 18,
+    paddingBottom: 20,
+    paddingTop: 20,
+  },
+  notes: {
+    alignItems: "baseline",
+    backgroundColor: theme.palette.backgroundSecondary.default,
+    borderRadius: 4,
+    fontSize: 14,
+    height: 150,
+    overflowY: "scroll",
+    padding: 16,
+  },
+  notesLabel: {
+    display: "none",
+  },
+  submitButton: {
+    marginLeft: 12,
+    marginRight: 24,
+  },
+}));
+
+export default useStyles;


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Add scroll to notes section](https://www.notion.so/uwblueprintexecs/Add-height-of-150px-and-overflow-y-scroll-to-the-notes-section-ac332fed2c4d484ca9c82b1bdab3c02b)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- added fixed height to notes section
- made it so that overflow behaviour is to scroll
- moved sidebar styles into a new file

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. Open the sidebar and start making a bunch of lines. Once you make enough lines you should be able to scroll inside the notes box.

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- testing

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
