### PR TITLE
Call post endpoint when creating a session

### DIFF
--- a/src/api/SessionAPI.ts
+++ b/src/api/SessionAPI.ts
@@ -1,5 +1,9 @@
 import * as APIUtils from "./APIUtils";
-import { SessionListResponse, SessionDetailResponse } from "./types";
+import {
+  SessionDetailResponse,
+  SessionListResponse,
+  SessionRequest,
+} from "./types";
 
 const getSessions = (): Promise<SessionListResponse[]> =>
   APIUtils.get("/sessions") as Promise<SessionListResponse[]>;
@@ -10,4 +14,7 @@ const getSession = (id: number): Promise<SessionDetailResponse> =>
 const exportSessions = (): Promise<string> =>
   APIUtils.get(`/export/sessions`, true) as Promise<string>;
 
-export default { getSessions, getSession, exportSessions };
+const postSession = (data: SessionRequest): Promise<SessionDetailResponse> =>
+  APIUtils.post("/sessions/", data) as Promise<SessionDetailResponse>;
+
+export default { getSessions, getSession, exportSessions, postSession };

--- a/src/components/sessions/session-config/SessionConfig.tsx
+++ b/src/components/sessions/session-config/SessionConfig.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { Box, OutlinedInput, Typography } from "@material-ui/core";
+import moment from "moment";
 
 import DateInput from "components/common/date-input";
 import FormRow from "components/common/form-row";
@@ -14,8 +15,8 @@ export enum TestId {
 type Props = {
   sessionName: string;
   onChangeSessionName: (name: string) => void;
-  startDate: Date | null;
-  onChangeStartDate: (date: Date | null) => void;
+  startDate: string;
+  onChangeStartDate: (date: string) => void;
 };
 
 const SessionConfig = ({
@@ -46,8 +47,12 @@ const SessionConfig = ({
       >
         <DateInput
           id="start-date"
-          value={startDate}
-          onChange={(date) => onChangeStartDate(date)}
+          onChange={(val) =>
+            onChangeStartDate(val ? moment(val).format("YYYY-MM-DD") : "")
+          }
+          value={
+            startDate === "" ? null : moment(startDate, "YYYY-MM-DD").toDate()
+          }
         />
       </FormRow>
     </Box>

--- a/src/components/sessions/session-config/SessionConfig.unit.test.tsx
+++ b/src/components/sessions/session-config/SessionConfig.unit.test.tsx
@@ -20,7 +20,7 @@ describe("SessionConfig", () => {
         <SessionConfig
           sessionName="Fall 2020"
           onChangeSessionName={onChangeSessionName}
-          startDate={new Date(2020, 9, 1)}
+          startDate="2020-10-01"
           onChangeStartDate={onChangeStartDate}
         />
       </MuiPickersUtilsProvider>
@@ -53,6 +53,6 @@ describe("SessionConfig", () => {
     await fireEvent.click(getByTestId(DateInputTestId.KeyboardButton));
     await fireEvent.click(await getByText("2"));
     expect(onChangeStartDate).toHaveBeenCalledTimes(1);
-    expect(onChangeStartDate).toHaveBeenCalledWith(new Date(2020, 9, 2));
+    expect(onChangeStartDate).toHaveBeenCalledWith("2020-10-02");
   });
 });

--- a/src/pages/create-session/CreateSession.tsx
+++ b/src/pages/create-session/CreateSession.tsx
@@ -9,8 +9,10 @@ import {
   Typography,
 } from "@material-ui/core";
 import { NavigateBefore } from "@material-ui/icons";
+import moment from "moment";
 import { useHistory } from "react-router-dom";
 
+import SessionAPI from "api/SessionAPI";
 import { SessionRequest } from "api/types";
 import FormEditor from "components/form-editor";
 import AddClasses from "components/sessions/add-classes";
@@ -40,7 +42,7 @@ const CreateSession = () => {
   const history = useHistory();
   const [session, setSession] = useState<SessionRequest>({
     name: "",
-    start_date: null,
+    start_date: moment(new Date()).format("YYYY-MM-DD"),
     fields: [],
     classes: [defaultClassData],
   });
@@ -77,14 +79,9 @@ const CreateSession = () => {
     setActiveStepIndex((prevActiveStepIndex) => prevActiveStepIndex - 1);
   };
 
-  const handleSubmit = () => {
-    // TODO: submit to the create session API
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const payload = {
-      name: session.name,
-      start_date: session.start_date,
-    };
-    goToSessions();
+  const handleSubmit = async () => {
+    const newSession = await SessionAPI.postSession(session);
+    history.push(`/sessions/${newSession.id}`);
   };
 
   const stepTitles = {
@@ -116,7 +113,6 @@ const CreateSession = () => {
             }
           />
         );
-      // fall through
       case CreateSessionStepLabel.ADD_CLASSES:
         return (
           <AddClasses

--- a/src/pages/create-session/CreateSession.tsx
+++ b/src/pages/create-session/CreateSession.tsx
@@ -80,8 +80,13 @@ const CreateSession = () => {
   };
 
   const handleSubmit = async () => {
-    const newSession = await SessionAPI.postSession(session);
-    history.push(`/sessions/${newSession.id}`);
+    try {
+      const newSession = await SessionAPI.postSession(session);
+      history.push(`/sessions/${newSession.id}`);
+    } catch (err) {
+      // eslint-disable-next-line no-alert
+      alert(err);
+    }
   };
 
   const stepTitles = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -84,7 +84,7 @@ export type Session = {
   fields: number[]; // array of field IDs
   id: number;
   name: string;
-  start_date: Date | null;
+  start_date: string;
 };
 
 export type Attendance = {


### PR DESCRIPTION
### Notion ticket link

<!-- Please replace with your ticket's URL -->

[Call the POST endpoint when users submit the session](https://www.notion.so/uwblueprintexecs/Developer-Hub-30e9b6c82af24054b31acf7c5e822c89?p=371d1a6ee3d247859ed3431c55122407)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

### Implementation description

- call the post endpoint when submitting
- updated start date type to a string to match the request format

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

### Steps to test

1. run the backend on uwblueprint/project-read-backend#
1. create a session and verify users navigate to the newly created session when clicking submit!

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

### What should reviewers focus on?

- testing

### Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] I have run the linter
- [x] I have requested a review from the PL, and/or other devs who have background knowledge on this PR or who will be building on top of this PR
